### PR TITLE
Fix the get author name partial to account for localized author names

### DIFF
--- a/layouts/partials/helpers/get-author-name.html
+++ b/layouts/partials/helpers/get-author-name.html
@@ -1,7 +1,12 @@
+{{/*  Uses the top level site's config for a single author across all locales  */}}
 {{ $authorName:= site.Params.author.name }}
-{{ if site.Data.site.author}}
-    {{ $authorName = site.Data.site.author.name }}
-{{ end}}
+
+{{/*  Overrides with the locale specifc author if provided  */}}
+{{ if (index site.Data site.Language.Lang).author }}
+  {{ $authorName = (index site.Data site.Language.Lang).author.name }}
+{{ end }}
+
+{{/*  Lastly, overrides with the post specific author if provided  */}}
 {{ if eq (printf "%T" .Params.author ) "maps.Params" }}
     {{ with .Params.author }}
         {{ if .name }}


### PR DESCRIPTION
### Issue
https://github.com/hugo-toha/toha/issues/140

### Description

The author name seemed to have the same issue as the avatar did where it wasn't taking into account the new language-specific configs seen [here](https://github.com/hugo-toha/toha/commit/d0c32c5d082c4fa6b09690e60ebf06a4c59713a2#diff-fb24974d85736fe816c6ff9a4909af0d3faf111ade7fffe5b83a3b99072bf2c9R1) but the author name in this case had no fallback. 

### Test Evidence

Before
![image](https://user-images.githubusercontent.com/8029578/97783070-9f1f2080-1b6b-11eb-91f6-efff5b59c111.png)
![image](https://user-images.githubusercontent.com/8029578/97783075-a2b2a780-1b6b-11eb-8e40-06564e53f065.png)

After:
![image](https://user-images.githubusercontent.com/8029578/97783077-a8a88880-1b6b-11eb-877e-f24b3eccb3de.png)
![image](https://user-images.githubusercontent.com/8029578/97783081-af370000-1b6b-11eb-858c-6565f6820add.png)
