### PR TITLE
Remove unnecessary uses of baseURL

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -35,7 +35,7 @@
   <div class="content">
     <div class="container p-0 read-area">
       <!--Hero Area-->
-      <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ strings.TrimSuffix "/" site.BaseURL }}{{ partial "helpers/get-hero.html" . | relURL }});'>
+      <div class="hero-area col-sm-12" id="hero-area" style='background-image: url({{ partial "helpers/get-hero.html" . | relURL }});'>
       </div>
 
       <!--Content Start-->

--- a/layouts/partials/sections/achievements/entry.html
+++ b/layouts/partials/sections/achievements/entry.html
@@ -1,6 +1,6 @@
 <div
   class="achievement-entry text-center"
-  style="background-image: url('{{ strings.TrimSuffix "/" site.BaseURL }}{{ .image | relURL }}');"
+  style="background-image: url('{{ .image | relURL }}');"
 >
   <i class="fas fa-search-plus" id="enlarge-icon"></i>
   <h4 class="title" id="achievement-title">{{ .title }}</h4>

--- a/layouts/partials/sections/home.html
+++ b/layouts/partials/sections/home.html
@@ -28,7 +28,7 @@
 <div class="container-fluid home" id="home">
   <div
     class="background container-fluid"
-    style="background-image: url('{{ strings.TrimSuffix "/" site.BaseURL }}{{ $backgroundImage | relURL }}');"
+    style="background-image: url('{{ $backgroundImage | relURL }}');"
   ></div>
   <div class="container content text-center">
     <img src="{{ $authorImage | relURL }}"


### PR DESCRIPTION
Remove unnecessary uses of baseURL that could block the site from functioning if the URL isn't working. This primarily should only impact when migrating domains from one hosting service to another, but could also cause issues when the baseURL domain isn't resolving for some reason.
