### PR TITLE
Fix smooth scroll

### DIFF
--- a/static/assets/js/main.js
+++ b/static/assets/js/main.js
@@ -37,7 +37,7 @@ var isMobile = false, isTablet = false, isLaptop = false;
             location.hostname == this.hostname
           ) {
             // Figure out element to scroll to
-            var target = $(this.hash);
+            var target = $(decodeURI(this.hash));
             target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
             // Does a scroll target exist?
             if (target.length) {


### PR DESCRIPTION
Smooth scroll doesn't work if a target link contains multibyte characters.
Decoding `this.hash` in `addSmoothScroll` can prevent.

### Issue

See https://github.com/hugo-toha/toha/issues/163

### Test Evidence

- Open https://hugo-toha.github.io/bn/posts/shortcodes/ in Chrome browser.

- Temporarily change codes in Chrome DevTools:
Line 40 in `static/assets/js/main.js`:
```diff
-             var target = $(this.hash);
+             var target = $(decodeURI(this.hash));
```

- Click any contents of right sidebar.

- Smooth scroll works.