### PR TITLE
Change the behavior of card links

### DIFF
--- a/layouts/partials/cards/project.html
+++ b/layouts/partials/cards/project.html
@@ -4,7 +4,7 @@
 >
   <div class="card mt-1">
     <div class="card">
-      <a class="card-header" href="{{ if .repo }}{{ .repo }}{{ else if .url }}{{ .url }}{{ else }}#{{ end }}">
+      <a class="card-header" href="{{ if .repo }}{{ .repo }}{{ else if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}">
         <div>
           <div class="d-flex">
             {{ if .logo }}

--- a/layouts/partials/cards/skill.html
+++ b/layouts/partials/cards/skill.html
@@ -1,5 +1,5 @@
 <div class="col-xs-12 col-sm-6 col-lg-4 pt-2">
-  <a class="skill-card-link" href="{{ if .url }}{{ .url }}{{ else }}#{{ end }}">
+  <a class="skill-card-link" href="{{ if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}">
     <div class="card">
       <div class="card-head d-flex">
         {{ if .icon }}


### PR DESCRIPTION
### Issue
If clicked the following objects, a page backs to top:
- Each skill card which has no `url`.
- Each project card which has neither `repo` nor `url`.

### Description

How about preventing from pages back if the cards have no links?

### Test Evidence

1. Add a skill and a project, then preview and click them.
1. See the page doesn't back to top.

- `exampleSite/data/en/sections/skills.yaml`

```yaml
skills:
- name: No url
  icon: "/images/sections/skills/c++.png"
  summary: "Know basic C/C++ programming. Used for contest programming and problem solving."
```

- `exampleSite/data/en/sections/projects.yaml`

```yaml
projects:
- name: No repo or url
  logo: /images/sections/projects/toha.png
  role: Owner
  timeline: "Jun 2019 - Present"
  summary: A Hugo theme for personal portfolio.
  tags: ["hobby","hugo","theme","professional"]
```