### PR TITLE
es -> it for italian language code

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -15,7 +15,7 @@ languages:
   fr:
     languageName: Français
     weight: 3
-  id: 
+  id:
     languageName: Indonesian
     weight: 4
   de:
@@ -24,7 +24,7 @@ languages:
   es:
     languageName: Spanish
     weight: 6
-  es:
+  it:
     languageName: Italian
     weight: 7
 


### PR DESCRIPTION
### Issue
When I use your exampleSite, I get this error:

```
Error in yaml.load(readLines(con), error.label = error.label, ...) : 
  (config.yaml) Duplicate map key: 'es'
```

See:
https://github.com/hugo-toha/toha/blob/7524654aeed3c3a22345481eb23cc3804e6b9fe8/exampleSite/config.yaml#L24-L29

### Description

I changed the Italian language code to `it`

### Test Evidence

Site builds locally for me now.