### PR TITLE
explicitly set the default language (needed for English not being the…

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,5 +1,6 @@
 baseURL: http://example.org/
 languageCode: en-us
+defaultContentLanguage: en
 title: "Toha"
 theme: "toha"
 


### PR DESCRIPTION
In case you don't want to use English as the default language, you need to set a different language with "defaultContentLanguage" in the config file. Otherwise the index page still would be rendered with English.