### PR TITLE
Markdownify copyright notice

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -97,7 +97,7 @@
           Toha
         </a>
       </div>
-      <div class="col-md-4 text-center">{{ $copyrightNotice }}</div>
+      <div class="col-md-4 text-center">{{ $copyrightNotice | markdownify }}</div>
       <div class="col-md-4 text-right">
         <a id="hugo" href="https://gohugo.io/">{{ i18n "hugoAttributionText" }}
         <img


### PR DESCRIPTION
### Issue
N/A

### Description
This PR adds a call to Hugo markdownify function when displaying copyright notice, thus allowing to write markdown in site.yaml "copyright" key

### Test Evidence
**site.yaml :**
```
# Copyright notice
copyright: "- © 2021 Copyright.\n- Background : [Kravers Photography](https://www.facebook.com/Kraversphotographie)"
```

**Render :**
![image](https://user-images.githubusercontent.com/26511053/104342532-381ed000-54fb-11eb-84e5-4c48bb32e240.png)

