### PR TITLE
parameterize git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toha
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/b1b93b02-f278-440b-ae1b-304e9f4c4ab5/deploy-status)](https://app.netlify.com/sites/toha/deploys) [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fhugo-toha%2Ftoha%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/hugo-toha/toha/goto?ref=master) ![Repository Size](https://img.shields.io/github/repo-size/hugo-toha/toha) ![Lines of Codes](https://img.shields.io/tokei/lines/github/hugo-toha/toha) ![Contributor](https://img.shields.io/github/contributors/hugo-toha/toha) ![Latest Release](https://img.shields.io/github/v/release/hugo-toha/toha?include_prereleases) ![Last Commit](https://img.shields.io/github/last-commit/hugo-toha/toha) ![Open Issues](https://img.shields.io/github/issues/hugo-toha/toha?color=important) ![Open Pull Requests](https://img.shields.io/github/issues-pr/hugo-toha/toha?color=yellowgreen)  ![License](https://img.shields.io/github/license/hugo-toha/toha) ![Security Headers](https://img.shields.io/security-headers?url=https%3A%2F%2Fhugo-toha.github.io%2F) [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/b7cb60ab/hugo-toha.github.io)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/b1b93b02-f278-440b-ae1b-304e9f4c4ab5/deploy-status)](https://app.netlify.com/sites/toha/deploys) [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fhugo-toha%2Ftoha%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/hugo-toha/toha/goto?ref=master) ![Repository Size](https://img.shields.io/github/repo-size/hugo-toha/toha) ![Lines of Codes](https://img.shields.io/tokei/lines/github/hugo-toha/toha) ![Contributor](https://img.shields.io/github/contributors/hugo-toha/toha) ![Latest Release](https://img.shields.io/github/v/release/hugo-toha/toha?include_prereleases) ![Last Commit](https://img.shields.io/github/last-commit/hugo-toha/toha) ![Open Issues](https://img.shields.io/github/issues/hugo-toha/toha?color=important) ![Open Pull Requests](https://img.shields.io/github/issues-pr/hugo-toha/toha?color=yellowgreen) ![License](https://img.shields.io/github/license/hugo-toha/toha) ![Security Headers](https://img.shields.io/security-headers?url=https%3A%2F%2Fhugo-toha.github.io%2F) [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/b7cb60ab/hugo-toha.github.io)
 
 A [Hugo](https://gohugo.io/) theme for a personal portfolio with minimalist design and responsiveness.
 
@@ -68,7 +68,7 @@ At first, add [Toha](https://github.com/hugo-toha/toha) theme as git submodule t
 $ git submodule add https://github.com/hugo-toha/toha.git themes/toha
 ```
 
->Don't use SSH URL of the theme during adding as git sub-module. Also, don't clone the theme in your `themes` directory using `git clone`. They don't work well with Github Action or Netlify.
+> Don't use SSH URL of the theme during adding as git sub-module. Also, don't clone the theme in your `themes` directory using `git clone`. They don't work well with Github Action or Netlify.
 
 If you don't already have a hugo site, create one by following the step by step guide from [here](https://toha-guides.netlify.app/posts/getting-started/prepare-site/).
 
@@ -102,8 +102,9 @@ enableEmoji: true
 
 # Site parameters
 params:
-  # GitHub repo URL of your site
+  # GitHub repo URL and branch of your site
   gitRepo: https://github.com/hugo-toha/hugo-toha.github.io
+  gitBranch: main
 
   # specify whether you want to write some blog posts or not
   enableBlogPost: true
@@ -145,12 +146,14 @@ Here, are the current plan and progress of various components of this theme. The
 ### Sections
 
 - [x] **Home**
+
   - [x] Configurable Background
   - [x] Author Image
   - [x] Greeting
   - [x] Typing Carousel
 
 - [x] **About**
+
   - [x] Name and Designation
   - [x] Summary
     - [x] Markdown Support
@@ -160,16 +163,19 @@ Here, are the current plan and progress of various components of this theme. The
   - [x] Soft Skills Indicator
 
 - [x] **Skills**
+
   - [x] Skill Cards
   - [x] Markdown Support
 
 - [x] **Experiences**
+
   - [x] Designation
   - [x] Timeline
   - [x] Company Overview
   - [x] Responsibilities
 
 - [ ] **Projects**
+
   - [x] Category Filter
   - [ ] Project Card
     - [x] Overview
@@ -181,6 +187,7 @@ Here, are the current plan and progress of various components of this theme. The
 - [x] **Recent Posts**
 
 - [ ] **Academic Career**
+
   - [ ] Degree
   - [ ] Institution
   - [ ] Timeline
@@ -189,6 +196,7 @@ Here, are the current plan and progress of various components of this theme. The
   - [ ] Extracurricular Activities
 
 - [ ] **Publications**
+
   - [ ] Category Filter
   - [ ] Card
   - [ ] Abstract
@@ -198,6 +206,7 @@ Here, are the current plan and progress of various components of this theme. The
   - [ ] Gallery
 
 - [ ] **Accomplishment / Courses**
+
   - [ ] Overview
   - [ ] Certificate
 
@@ -246,7 +255,7 @@ Pull requests are most welcome and I will be happy to review. Just follow the fo
 - Use as few dependencies as possible.
 - Have patience.
 
->I am not a web developer. I have created this theme for my personal needs. So, it is reasonable to have some flaws in the codes. Feel free to open issues and PRs acknowledging the problems.
+> I am not a web developer. I have created this theme for my personal needs. So, it is reasonable to have some flaws in the codes. Feel free to open issues and PRs acknowledging the problems.
 
 ## Local Development
 

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -69,6 +69,7 @@ params:
 
   # GitHub repo URL of your site
   gitRepo: https://github.com/hugo-toha/hugo-toha.github.io
+  gitBranch: main
 
   # specify whether you want to write some blog posts or not
   enableBlogPost: true

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -57,7 +57,7 @@
         <!--- Improve this page button --->
         {{ if site.Params.GitRepo }}
           <div class="btn-improve-page">
-              <a href="{{ site.Params.GitRepo }}/edit/master/content/{{ .File.Path }}">
+              <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}">
                 <i class="fas fa-code-branch"></i>
                 {{ i18n "improve_this_page" }}
               </a>


### PR DESCRIPTION
### Issue
#202 

### Description

With GitHub pivoting from using `master` to `main` as the default branch in a repository, users may have either of the two branch names as their default, or maybe something else.

This PR creates a new parameter of `gitBranch` in the `config.yml` file, and defaults it to the current default value on GitHub: `main`.

### Test Evidence

- [A blog entry on my site, using Toha](https://github.com/santiagon610/personal-website/blob/main/content/posts/20201030_scofield.md)
  - [Markdown source of blog post](https://github.com/santiagon610/personal-website/blob/main/content/posts/20201030_scofield.md)
  - [Git commit to parameterize on my personal repo](https://github.com/santiagon610/personal-website/commit/dc28befd5a31278adf690f4ebcae9f333b1ee54a)