### PR TITLE
Add optional variable to education for courses where scaling doesn't make sense

### DIFF
--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -52,18 +52,18 @@
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses" }}</h6>
                                 {{ if .takenCourses.showGrades }}
-                                {{ $isScale := .takenCourses.isScale }}
+                                {{ $dontScale := .takenCourses.dontScale}}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name" }}</th>
-                                        {{ if $isScale }}<th>{{ i18n "total_credit" }}</th>{{ end }}
+                                        {{ if not $dontScale }}<th>{{ i18n "total_credit" }}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit" }}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            {{ if $isScale }}<td>{{ $course.outOf }}</td>{{ end }}
+                                            {{ if not $dontScale }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -52,18 +52,18 @@
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses" }}</h6>
                                 {{ if .takenCourses.showGrades }}
-                                {{ $dontScale := .takenCourses.dontScale}}
+                                {{ $hideScale  := .takenCourses.hideScale }}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name" }}</th>
-                                        {{ if not $dontScale }}<th>{{ i18n "total_credit" }}</th>{{ end }}
+                                        {{ if not $hideScale  }}<th>{{ i18n "total_credit" }}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit" }}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            {{ if not $dontScale }}<td>{{ $course.outOf }}</td>{{ end }}
+                                            {{ if not $hideScale  }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -51,18 +51,19 @@
                             {{ if .takenCourses }}
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses" }}</h6>
-                                {{ if .takenCourses.showGrades }}    
+                                {{ if .takenCourses.showGrades }}
+                                {{ $isScale := .takenCourses.isScale }}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name" }}</th>
-                                        <th>{{ i18n "total_credit" }}</th>
+                                        {{ if $isScale }}<th>{{ i18n "total_credit" }}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit" }}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            <td>{{ $course.outOf }}</td>
+                                            {{ if $isScale }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -51,18 +51,19 @@
                             {{ if .takenCourses }}
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses"}}</h6>
-                                {{ if .takenCourses.showGrades }}    
+                                {{ if .takenCourses.showGrades }}
+                                {{ $isScale := .takenCourses.isScale }}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name"}}</th>
-                                        <th>{{ i18n "total_credit"}}</th>
+                                        {{ if $isScale }}<th>{{ i18n "total_credit"}}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit"}}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            <td>{{ $course.outOf }}</td>
+                                            {{ if $isScale }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -52,18 +52,18 @@
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses"}}</h6>
                                 {{ if .takenCourses.showGrades }}
-                                {{ $isScale := .takenCourses.isScale }}
+                                {{ $dontScale := .takenCourses.dontScale}}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name"}}</th>
-                                        {{ if $isScale }}<th>{{ i18n "total_credit"}}</th>{{ end }}
+                                        {{ if not $dontScale }}<th>{{ i18n "total_credit"}}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit"}}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            {{ if $isScale }}<td>{{ $course.outOf }}</td>{{ end }}
+                                            {{ if not $dontScale }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -52,18 +52,18 @@
                             <div class="taken-courses">
                                 <h6 class="text-muted">{{ i18n "taken_courses"}}</h6>
                                 {{ if .takenCourses.showGrades }}
-                                {{ $dontScale := .takenCourses.dontScale}}
+                                {{ $hideScale  := .takenCourses.hideScale }}
                                 <table>
                                     <thead>
                                         <th>{{ i18n "course_name"}}</th>
-                                        {{ if not $dontScale }}<th>{{ i18n "total_credit"}}</th>{{ end }}
+                                        {{ if not $hideScale  }}<th>{{ i18n "total_credit"}}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit"}}</th>
                                     </thead>
                                     <tbody>
                                         {{ range $index,$course := .takenCourses.courses }}
                                         <tr class="course {{ if gt $index 1 }}hidden-course{{ end}}">
                                             <td>{{ $course.name }}</td>
-                                            {{ if not $dontScale }}<td>{{ $course.outOf }}</td>{{ end }}
+                                            {{ if not $hideScale  }}<td>{{ $course.outOf }}</td>{{ end }}
                                             <td>{{ $course.achieved }}</td>
                                         </tr>
                                         {{ end }}


### PR DESCRIPTION
### Description

For some cultures listing the total credits for a course doesn't make sense, especially for some tiers of education, where the scale is universally used and accepted, thus it's self-explanatory.

This change introduces a optional key under `takenCourses` called `dontScale`(key-name is obviously up for discussion), which prevents the rendering of the `total_credit` row and therefore `outOf` in the course section allowing for courses to not necessarily present as a scale. 

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->
![image](https://user-images.githubusercontent.com/7110194/108005811-0917e480-6ffa-11eb-8a5a-3d4a71d1f205.png)


From the following yaml
```yml
degrees:
  - name: General subject
    icon: fa-graduation-cap
    timeframe: 2018-2019
    institution:
      name: Upper Secondary School
      url: "#"
    takenCourses:
      showGrades: true
      courses:
        - name: English
          achieved: 3
          outOf: 6
        - name: 2nd Paractical Mathematics
          achieved: 4
          outOf: 6

  - name: Upper School Certificate
    icon: fa-school
    timeframe: 2015-2019
    institution:
      name: Upper Secondary School
      url: "#"
    takenCourses:
      showGrades: true
      dontScale: true
      courses:
        - name: Operation and maintenance
          achieved: 5
          outOf: 6
        - name: User support
          achieved: 5
          outOf: 6

  - name: Upper School Certificate
    icon: fa-school
    timeframe: 2014-2015
    institution:
      name: Upper Secondary School
      url: "#"
    takenCourses:
      showGrades: true
      dontScale: false
      courses:
        - name: Planning
          achieved: 4
          outOf: 6
        - name: Opperation and follow-up
          achieved: 5
          outOf: 6
```