### PR TITLE
Add a `tel:` link to the About Page

### DIFF
--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -30,6 +30,8 @@
           <li>
             {{ if eq .name "Email" }}
               <a href="mailto:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
+            {{ else if eq .name "Phone" }}
+              <a href="tel:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
             {{ else }}
               <a href="{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
             {{ end }}


### PR DESCRIPTION
just like a `mailto:` link triggers an email, a `tel:` link will allow you to call someone directly from the page. I've added this.

### Issue
No Issue, Enhancement

### Description

Adds a direct-dial link to the about page allowing visitors to directly make a phone call from a webpage

### Test Evidence

![Screen Shot 2021-03-11 at 8 40 54 AM](https://user-images.githubusercontent.com/2071898/110796908-7c51f680-8246-11eb-85e7-61149dbf766f.png)
![Screen Shot 2021-03-11 at 8 41 10 AM](https://user-images.githubusercontent.com/2071898/110796913-7eb45080-8246-11eb-83d8-1602b9b04cfa.png)
