### PR TITLE
Fix to the hero so you can have the image named anything you want

### DIFF
--- a/layouts/partials/helpers/get-hero.html
+++ b/layouts/partials/helpers/get-hero.html
@@ -1,5 +1,10 @@
 {{/* check if there is any hero image in the same folder as the markdown file */}}
-{{ $heroImage := .Page.Resources.GetMatch .Params.hero}}
+{{ $heroImage := .Page.Resources.GetMatch "hero.{jpg,png,svg}"}}
+
+{{/*  if hero image is specified in the page front-matter, then use that  */}}
+{{ if .Params.hero }}
+  {{ $heroImage = .Page.Resources.GetMatch .Params.hero }}
+{{ end }}
 {{ .Scratch.Set "heroScratch" $heroImage }}
 
 {{/* if hero image is not provided, then use the default hero image */}}

--- a/layouts/partials/helpers/get-hero.html
+++ b/layouts/partials/helpers/get-hero.html
@@ -1,5 +1,5 @@
 {{/* check if there is any hero image in the same folder as the markdown file */}}
-{{ $heroImage := .Page.Resources.GetMatch "hero.{jpg,png,svg}"}}
+{{ $heroImage := .Page.Resources.GetMatch .Params.hero}}
 {{ .Scratch.Set "heroScratch" $heroImage }}
 
 {{/* if hero image is not provided, then use the default hero image */}}


### PR DESCRIPTION
### Issue
fixes https://github.com/hugo-toha/toha/issues/223
### Description

Before, you **had** to name your hero file "hero.[jpg|.png|.svg]" and nothing else would work. 
With this fix, it will pick up the name of your file from the Front Matter:
```
hero: images/my-hero.png"
```

### Test Evidence
![Screen Shot 2021-03-11 at 4 24 26 PM](https://user-images.githubusercontent.com/2071898/110857199-8c89c600-8286-11eb-8d4f-86c8037391f5.png)
![Screen Shot 2021-03-11 at 4 25 06 PM](https://user-images.githubusercontent.com/2071898/110857217-91e71080-8286-11eb-8e86-2a684c7d8be8.png)
![Screen Shot 2021-03-11 at 4 25 22 PM](https://user-images.githubusercontent.com/2071898/110857231-97445b00-8286-11eb-832f-07860920c667.png)
