### PR TITLE
Fix missing vertical separator in navbar menu

### DIFF
--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -23,6 +23,11 @@
 {{ end }}
 {{ $invertedLogo = $invertedLogo.RelPermalink}}
 
+{{ $customMenus := site.Params.customMenus }}
+{{ if (index site.Data site.Language.Lang).site.customMenus }}
+  {{ $customMenus = (index site.Data site.Language.Lang).site.customMenus }}
+{{ end }}
+
 {{ $sections := site.Data.sections }}
 {{ if (index site.Data site.Language.Lang).sections }}
   {{ $sections = (index site.Data site.Language.Lang).sections }}
@@ -63,8 +68,8 @@
           {{- end }}
         {{- end }}
         {{ $hasCustomMenus:= false }}
-        {{ if and site.Params.customMenus }}
-          {{ if gt (len site.Params.customMenus) 0 }}
+        {{ if $customMenus }}
+          {{ if gt (len $customMenus) 0 }}
             {{ $hasCustomMenus = true }}
           {{ end }}
         {{ end }}
@@ -76,7 +81,7 @@
             <a class="nav-link" id="blog-link" href="{{ "/posts" | relLangURL }}">{{ i18n "posts" }}</a>
           </li>
         {{ end }}
-        {{ range  (index site.Data site.Language.Lang).site.customMenus }}
+        {{ range $customMenus }}
           <li class="nav-item">
             <a class="nav-link" href="{{ .url }}">{{ .name }}</a>
           </li>


### PR DESCRIPTION
### Issue

Resolve #255

### Description

I've created a new variable `$customMenus` which has by default a value of `site.Params.customMenus`.
The problem causing the bug was that it didn't check the language-scope `customMenu` value.

But it does now :)

*The same value is being reused to iterate over those custom links and to display them, so I have replaced it with the variable.*

### Test Evidence

![menu](https://user-images.githubusercontent.com/51094650/112040815-f12a0800-8b45-11eb-86f5-2eb6256af00b.png)
![menu-2](https://user-images.githubusercontent.com/51094650/112040561-a8724f00-8b45-11eb-8998-17c4bae805e6.png)
![menu-3](https://user-images.githubusercontent.com/51094650/112040567-aa3c1280-8b45-11eb-8dc4-0f698ee32828.png)
