### PR TITLE
Fix inconsistencies in target attributes

### DIFF
--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -29,11 +29,11 @@
           {{ range .socialLinks }}
           <li>
             {{ if eq .name "Email" }}
-              <a href="mailto:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
+              <a href="mailto:{{ .url }}" target="_blank"><i class="{{ .icon }}"></i></a>
             {{ else if eq .name "Phone" }}
-              <a href="tel:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
+              <a href="tel:{{ .url }}" target="_blank"><i class="{{ .icon }}"></i></a>
             {{ else }}
-              <a href="{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
+              <a href="{{ .url }}" target="_blank"><i class="{{ .icon }}"></i></a>
             {{ end }}
           </li>
           {{ end }}


### PR DESCRIPTION
### Description

Currently there are two ways how the code opens links in new tabs:

* `target="/"`
* `target="_blank"` (in #278)

Both attributes work well but there shouldn't be two ways of doing one thing.

I didn't manage to find how exactly the first one (`target="/"`) works so I decided to go with the second
solution (`target="_blank"`). Also according to these resources this is the "correct" way to handle these situations:

https://www.w3schools.com/tags/att_a_target.asp (`"/"` is not even an option)
https://css-tricks.com/all-about-mailto-links/#open-in-new-tab-sometimes-does-matter (`"_blank"` is used in the same context)

If there is any particular reason to use `"/"` please let me know.