### PR TITLE
Fix redirections to empty tabs

### DIFF
--- a/layouts/partials/cards/accomplishments.html
+++ b/layouts/partials/cards/accomplishments.html
@@ -11,7 +11,9 @@
       <p>{{ .courseOverview | markdownify }}</p>
     </div>
     <div class="card-footer">
-      <a class="btn btn-outline-info ml-1 pl-2 mb-2" href="{{ .certificateURL | default "#"}}" target="_blank" role="button">{{ i18n "view_certificate"}}</a>
+      {{ if .certificateURL }}
+        <a class="btn btn-outline-info ml-1 pl-2 mb-2" href="{{ .certificateURL }}" target="_blank" role="button">{{ i18n "view_certificate"}}</a>
+      {{ end }}
     </div>
   </div>
 </div>

--- a/layouts/partials/cards/project.html
+++ b/layouts/partials/cards/project.html
@@ -4,7 +4,7 @@
 >
   <div class="card mt-1">
     <div class="card">
-      <a class="card-header" href="{{ if .repo }}{{ .repo }}{{ else if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}" target="_blank">
+      <a class="card-header" href="{{ if .repo }}{{ .repo }}{{ else if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}" {{ if or .repo .url }}target="_blank"{{ end }}>
         <div>
           <div class="d-flex">
             {{ if .logo }}

--- a/layouts/partials/cards/skill.html
+++ b/layouts/partials/cards/skill.html
@@ -1,5 +1,5 @@
 <div class="col-xs-12 col-sm-6 col-lg-4 pt-2">
-  <a class="skill-card-link" href="{{ if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}" target="_blank">
+  <a class="skill-card-link" href="{{ if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}" {{ if .url }}target="_blank"{{ end }}>
     <div class="card">
       <div class="card-head d-flex">
         {{ if .logo }}

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -27,7 +27,7 @@
                             <div class="row">
                                 <div class="col-lg-10 col-md-8">
                                     {{ if .institution.url }}
-                                        <h5><a href="{{ .institution.url }}">{{ .institution.name }}</a></h5>
+                                        <h5><a href="{{ .institution.url }}" target="_blank">{{ .institution.name }}</a></h5>
                                     {{ else }}
                                         <h5>{{ .institution.name }}</h5>
                                     {{ end }}
@@ -43,7 +43,11 @@
                                     <h6 class="text-muted">{{i18n "publications"}}</h6>
                                     <ul>
                                         {{ range .publications }}
-                                            <li><a href="{{ .url }} ">{{ .title }}</a></li>
+                                            {{ if .url }}
+                                                <li><a href="{{ .url }}" target="_blank">{{ .title }}</a></li>
+                                            {{ else }}
+                                                <li>{{ .title }}</li>
+                                            {{ end }}
                                         {{ end }}
                                     </ul>
                                 </div>

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -43,7 +43,11 @@
                                     <h6 class="text-muted">{{ i18n "publications"}}</h6>
                                     <ul>
                                         {{ range .publications }}
-                                            <li><a href="{{ .url }} " target="_blank">{{ .title }}</a></li>
+                                            {{ if .url }}
+                                                <li><a href="{{ .url }}" target="_blank">{{ .title }}</a></li>
+                                            {{ else }}
+                                                <li>{{ .title }}</li>
+                                            {{ end }}
                                         {{ end }}
                                     </ul>
                                 </div>


### PR DESCRIPTION
### Problem

Whenever href (url) attribute was omitted or had no value
the click action would do nothing. With no URLs defined and
`target="_blank"` attributes, which were recently added,
anchor tags now redirect users to new blank tabs (side effect).

### Solution

This PR solves the issues by adding conditions
before applying `target="_blank"` or in some cases by
ommiting entire entities (e.g. the view_certificate button).