### PR TITLE
Refactor target values of redirections to external pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -59,7 +59,7 @@
         <!--- Improve this page button --->
         {{ if site.Params.GitRepo }}
           <div class="btn-improve-page">
-              <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}">
+              <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" target="_blank">
                 <i class="fas fa-code-branch"></i>
                 {{ i18n "improve_this_page" }}
               </a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -92,14 +92,14 @@
   <div class="container">
     <div class="row text-left">
       <div class="col-md-4">
-        <a id="theme" href="https://github.com/hossainemruz/toha" target="#">
+        <a id="theme" href="https://github.com/hossainemruz/toha" target="_blank">
           <img src="{{ $themeLogo }}" alt="Toha Theme Logo">
           Toha
         </a>
       </div>
       <div class="col-md-4 text-center">{{ $copyrightNotice | markdownify }}</div>
       <div class="col-md-4 text-right">
-        <a id="hugo" href="https://gohugo.io/">{{ i18n "hugoAttributionText" }}
+        <a id="hugo" href="https://gohugo.io/" target="_blank">{{ i18n "hugoAttributionText" }}
         <img
           src="{{ $hugoLogo }}"
           alt="Hugo Logo"


### PR DESCRIPTION
## Proposal

I believe we have really improved UX by opening **section external links** in new tabs (#278). On the other hand, I don't think we should stop there. I would do the same for **all links** that redirect to external sites, which typically have no backlinks to our website. Therefore, I think it would be nice to open all these links in new browser tabs as well.

### Changes

This commit adds three `target="_blank"` attributes to anchor tags:

* in the footer:
  * gh repo of the toha theme
  * hugo official website
* _"improve this page"_ button.