### PR TITLE
Allow footer configuration

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,8 @@
     </div>
 
     <!------- ADD FOOTER ------------>
-    {{- partial "footer.html" . -}}
+    {{ $footerTemplate:= site.Params.footer.template | default "footer.html" }}
+    {{- partial $footerTemplate . -}}
 
     <!------- ADD COMMON SCRIPTS ------->
     {{ partial "scripts.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -66,7 +66,8 @@
     {{ end }}
 
     <!--- ADD FOOTER ----------------------->
-    {{- partial "footer.html" . -}}
+    {{ $footerTemplate:= site.Params.footer.template | default "footer.html" }}
+    {{- partial $footerTemplate . -}}
 
     <!--- ADD COMMON SCRIPTS --------------->
     {{ partial "scripts.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,8 +2,13 @@
 {{ $footerEnabled      := site.Params.footer.enable             | default true }}
 {{ $navigationEnabled  := site.Params.footer.navigation.enable  | default true }}
 {{ $contactMeEnabled   := site.Params.footer.contactMe.enable   | default true }}
-{{ $newsLetterEnabled  := site.Params.newsletter.enable         | default false }}
+{{ $newsletterEnabled  := site.Params.footer.newsletter.enable  | default true }}
 {{ $credentialsEnabled := site.Params.footer.credentials.enable | default true }}
+
+{{/*  Keep backward compatibility for the newsletter function */}}
+{{ if site.Params.newsletter.enable }}
+  {{ $newsletterEnabled = true }}
+{{ end }}
 
 {{ if $footerEnabled }}
   {{ $author:= site.Data.author }}
@@ -16,7 +21,7 @@
     {{ $sections = (index site.Data site.Language.Lang).sections }}
   {{ end }}
 
-  {{ $copyrightNotice := "© 2020 Copyright."}}
+  {{ $copyrightNotice := "© 2021 Copyright."}}
   {{ if (index site.Data site.Language.Lang).site }}
     {{ $siteConfig := (index site.Data site.Language.Lang).site }}
     {{ if $siteConfig.copyright }}
@@ -74,7 +79,7 @@
           </ul>
         </div>
         {{ end }}
-        {{ if $newsLetterEnabled }}
+        {{ if $newsletterEnabled }}
         <div class="col-md-4 col-sm-12">
           <!-- <h5>Newsletter</h5> -->
           <p>{{ i18n "newsletter_text" }}</p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,6 +2,7 @@
 {{ $navigationEnabled := site.Params.footer.navigation.enable | default true }}
 {{ $contactMeEnabled := site.Params.footer.contactMe.enable | default true }}
 {{ $newsLetterEnabled := site.Params.newsletter.enable }}
+{{ $credentialsEnabled := site.Params.footer.credentials.enable | default true }}
 
 {{ if $footerEnabled }}
   {{ $author:= site.Data.author }}
@@ -95,6 +96,7 @@
         {{ end }}
       </div>
     </div>
+    {{ if $credentialsEnabled }}
     <hr />
     <div class="container">
       <div class="row text-left">
@@ -116,5 +118,6 @@
         </div>
       </div>
     </div>
+    {{ end }}
   </footer>
 {{end}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
 {{ $footerEnabled := site.Params.footer.enable | default true }}
+{{ $contactMeEnabled := site.Params.footer.contactMe.enable | default true }}
 
 {{ if $footerEnabled }}
   {{ $author:= site.Data.author }}
@@ -58,7 +59,7 @@
           {{ end }}
 
         </div>
-        {{ if $author }}
+        {{ if (and $contactMeEnabled $author) }}
         <div class="col-md-4 col-sm-12">
           <h5>{{ i18n "contact_me" }}</h5>
           <ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,112 +1,116 @@
-{{ $author:= site.Data.author }}
-{{ if (index site.Data site.Language.Lang).author }}
-  {{ $author = (index site.Data site.Language.Lang).author }}
-{{ end }}
+{{ $footerEnabled := site.Params.footer.enable | default true }}
 
-{{ $sections:= site.Data.sections }}
-{{ if (index site.Data site.Language.Lang).sections }}
-  {{ $sections = (index site.Data site.Language.Lang).sections }}
-{{ end }}
-
-{{ $copyrightNotice := "© 2020 Copyright."}}
-{{ if (index site.Data site.Language.Lang).site }}
-  {{ $siteConfig := (index site.Data site.Language.Lang).site }}
-  {{ if $siteConfig.copyright }}
-    {{ $copyrightNotice = $siteConfig.copyright }}
+{{ if $footerEnabled }}
+  {{ $author:= site.Data.author }}
+  {{ if (index site.Data site.Language.Lang).author }}
+    {{ $author = (index site.Data site.Language.Lang).author }}
   {{ end }}
-{{ end }}
 
-{{/*  footer logos  */}}
-{{ $themeLogo := "/images/theme-logo.png" }}
-{{ $hugoLogo := "/images/hugo-logo.svg" }}
+  {{ $sections:= site.Data.sections }}
+  {{ if (index site.Data site.Language.Lang).sections }}
+    {{ $sections = (index site.Data site.Language.Lang).sections }}
+  {{ end }}
 
-{{/* resize the logos. don't resize svg because it is not supported */}}
-{{ $themeLogo:= resources.Get $themeLogo}}
-{{ if and $themeLogo (ne $themeLogo.MediaType.SubType "svg") }}
-  {{ $themeLogo = $themeLogo.Resize "32x" }}
-{{ end }}
-{{ $themeLogo = $themeLogo.RelPermalink}}
+  {{ $copyrightNotice := "© 2020 Copyright."}}
+  {{ if (index site.Data site.Language.Lang).site }}
+    {{ $siteConfig := (index site.Data site.Language.Lang).site }}
+    {{ if $siteConfig.copyright }}
+      {{ $copyrightNotice = $siteConfig.copyright }}
+    {{ end }}
+  {{ end }}
 
-{{ $hugoLogo:= resources.Get $hugoLogo}}
-{{ if and $hugoLogo (ne $hugoLogo.MediaType.SubType "svg")}}
-  {{ $hugoLogo = $hugoLogo.Resize "32x" }}
-{{ end }}
-{{ $hugoLogo = $hugoLogo.RelPermalink}}
+  {{/*  footer logos  */}}
+  {{ $themeLogo := "/images/theme-logo.png" }}
+  {{ $hugoLogo := "/images/hugo-logo.svg" }}
 
-<footer class="container-fluid text-center align-content-center footer pb-2">
-  <div class="container pt-5">
-    <div class="row text-left">
-      <div class="col-md-4 col-sm-12">
-        <h5>{{ i18n "navigation" }}</h5>
-        {{ if $sections }}
-        <ul>
-          {{- range sort $sections "section.weight" }}
-            {{ if and (.section.enable) (.section.showOnNavbar)}}
-              {{ $sectionID := replace (lower .section.name) " " "-"  }}
-              {{ if .section.id }}
-                {{ $sectionID = .section.id }}
+  {{/* resize the logos. don't resize svg because it is not supported */}}
+  {{ $themeLogo:= resources.Get $themeLogo}}
+  {{ if and $themeLogo (ne $themeLogo.MediaType.SubType "svg") }}
+    {{ $themeLogo = $themeLogo.Resize "32x" }}
+  {{ end }}
+  {{ $themeLogo = $themeLogo.RelPermalink}}
+
+  {{ $hugoLogo:= resources.Get $hugoLogo}}
+  {{ if and $hugoLogo (ne $hugoLogo.MediaType.SubType "svg")}}
+    {{ $hugoLogo = $hugoLogo.Resize "32x" }}
+  {{ end }}
+  {{ $hugoLogo = $hugoLogo.RelPermalink}}
+
+  <footer class="container-fluid text-center align-content-center footer pb-2">
+    <div class="container pt-5">
+      <div class="row text-left">
+        <div class="col-md-4 col-sm-12">
+          <h5>{{ i18n "navigation" }}</h5>
+          {{ if $sections }}
+          <ul>
+            {{- range sort $sections "section.weight" }}
+              {{ if and (.section.enable) (.section.showOnNavbar)}}
+                {{ $sectionID := replace (lower .section.name) " " "-"  }}
+                {{ if .section.id }}
+                  {{ $sectionID = .section.id }}
+                {{ end }}
+                <li class="nav-item">
+                  <a class="smooth-scroll" href="/#{{ $sectionID }}">{{ .section.name }}</a>
+                </li>
               {{ end }}
-              <li class="nav-item">
-                <a class="smooth-scroll" href="/#{{ $sectionID }}">{{ .section.name }}</a>
-              </li>
-            {{ end }}
-          {{- end }}
-        </ul>
-        {{ end }}
-
-      </div>
-      {{ if $author }}
-      <div class="col-md-4 col-sm-12">
-        <h5>{{ i18n "contact_me" }}</h5>
-        <ul>
-          {{ range $key,$value:= $author.contactInfo }}
-          <li><span>{{ title $key }}: </span> <span>{{ $value }}</span></li>
+            {{- end }}
+          </ul>
           {{ end }}
-        </ul>
-      </div>
-      {{ end }}
-      {{ if site.Params.newsletter.enable }}
-      <div class="col-md-4 col-sm-12">
-        <!-- <h5>Newsletter</h5> -->
-        <p>{{ i18n "newsletter_text" }}</p>
-        <form>
-          <div class="form-group">
-            <input
-              type="email"
-              class="form-control"
-              id="exampleInputEmail1"
-              aria-describedby="emailHelp"
-              placeholder="{{ i18n "newsletter_input_placeholder" }}"
-            />
-            <small id="emailHelp" class="form-text text-muted"
-              >{{ i18n "newsletter_warning" }}</small
-            >
-          </div>
-          <button type="submit" class="btn btn-info">{{ i18n "submit" }}</button>
-        </form>
-      </div>
-      {{ end }}
-    </div>
-  </div>
-  <hr />
-  <div class="container">
-    <div class="row text-left">
-      <div class="col-md-4">
-        <a id="theme" href="https://github.com/hossainemruz/toha" target="_blank" rel="noopener">
-          <img src="{{ $themeLogo }}" alt="Toha Theme Logo">
-          Toha
-        </a>
-      </div>
-      <div class="col-md-4 text-center">{{ $copyrightNotice | markdownify }}</div>
-      <div class="col-md-4 text-right">
-        <a id="hugo" href="https://gohugo.io/" target="_blank" rel="noopener">{{ i18n "hugoAttributionText" }}
-        <img
-          src="{{ $hugoLogo }}"
-          alt="Hugo Logo"
-          height="18"
-        />
-        </a>
+
+        </div>
+        {{ if $author }}
+        <div class="col-md-4 col-sm-12">
+          <h5>{{ i18n "contact_me" }}</h5>
+          <ul>
+            {{ range $key,$value:= $author.contactInfo }}
+            <li><span>{{ title $key }}: </span> <span>{{ $value }}</span></li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
+        {{ if site.Params.newsletter.enable }}
+        <div class="col-md-4 col-sm-12">
+          <!-- <h5>Newsletter</h5> -->
+          <p>{{ i18n "newsletter_text" }}</p>
+          <form>
+            <div class="form-group">
+              <input
+                type="email"
+                class="form-control"
+                id="exampleInputEmail1"
+                aria-describedby="emailHelp"
+                placeholder="{{ i18n "newsletter_input_placeholder" }}"
+              />
+              <small id="emailHelp" class="form-text text-muted"
+                >{{ i18n "newsletter_warning" }}</small
+              >
+            </div>
+            <button type="submit" class="btn btn-info">{{ i18n "submit" }}</button>
+          </form>
+        </div>
+        {{ end }}
       </div>
     </div>
-  </div>
-</footer>
+    <hr />
+    <div class="container">
+      <div class="row text-left">
+        <div class="col-md-4">
+          <a id="theme" href="https://github.com/hossainemruz/toha" target="_blank" rel="noopener">
+            <img src="{{ $themeLogo }}" alt="Toha Theme Logo">
+            Toha
+          </a>
+        </div>
+        <div class="col-md-4 text-center">{{ $copyrightNotice | markdownify }}</div>
+        <div class="col-md-4 text-right">
+          <a id="hugo" href="https://gohugo.io/" target="_blank" rel="noopener">{{ i18n "hugoAttributionText" }}
+          <img
+            src="{{ $hugoLogo }}"
+            alt="Hugo Logo"
+            height="18"
+          />
+          </a>
+        </div>
+      </div>
+    </div>
+  </footer>
+{{end}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
 {{ $footerEnabled := site.Params.footer.enable | default true }}
+{{ $navigationEnabled := site.Params.footer.navigation.enable | default true }}
 {{ $contactMeEnabled := site.Params.footer.contactMe.enable | default true }}
 {{ $newsLetterEnabled := site.Params.newsletter.enable }}
 
@@ -41,6 +42,7 @@
   <footer class="container-fluid text-center align-content-center footer pb-2">
     <div class="container pt-5">
       <div class="row text-left">
+        {{ if $navigationEnabled }}
         <div class="col-md-4 col-sm-12">
           <h5>{{ i18n "navigation" }}</h5>
           {{ if $sections }}
@@ -58,8 +60,8 @@
             {{- end }}
           </ul>
           {{ end }}
-
         </div>
+        {{ end }}
         {{ if (and $contactMeEnabled $author) }}
         <div class="col-md-4 col-sm-12">
           <h5>{{ i18n "contact_me" }}</h5>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,6 @@
 {{ $footerEnabled := site.Params.footer.enable | default true }}
 {{ $contactMeEnabled := site.Params.footer.contactMe.enable | default true }}
+{{ $newsLetterEnabled := site.Params.newsletter.enable }}
 
 {{ if $footerEnabled }}
   {{ $author:= site.Data.author }}
@@ -69,7 +70,7 @@
           </ul>
         </div>
         {{ end }}
-        {{ if site.Params.newsletter.enable }}
+        {{ if $newsLetterEnabled }}
         <div class="col-md-4 col-sm-12">
           <!-- <h5>Newsletter</h5> -->
           <p>{{ i18n "newsletter_text" }}</p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,8 @@
-{{ $footerEnabled := site.Params.footer.enable | default true }}
-{{ $navigationEnabled := site.Params.footer.navigation.enable | default true }}
-{{ $contactMeEnabled := site.Params.footer.contactMe.enable | default true }}
-{{ $newsLetterEnabled := site.Params.newsletter.enable }}
+{{/*  variables for enabling/disabling parts of the footer  */}}
+{{ $footerEnabled      := site.Params.footer.enable             | default true }}
+{{ $navigationEnabled  := site.Params.footer.navigation.enable  | default true }}
+{{ $contactMeEnabled   := site.Params.footer.contactMe.enable   | default true }}
+{{ $newsLetterEnabled  := site.Params.newsletter.enable         | default false }}
 {{ $credentialsEnabled := site.Params.footer.credentials.enable | default true }}
 
 {{ if $footerEnabled }}


### PR DESCRIPTION
Introduced some new configuration options. These are the default values:

```yaml
params:
  footer:
    enable: true
    navigation:
      enable: true
    contactMe:
      enable: true
    credentials:
      enable: true
  newsletter: # not new, but similar to new options
    enable: false
```

Where should the documentation go?

Please note that I am technically a web developer, but not familiar with hugo in the slightest. I am very happy about constructive feedback.

Btw it might be easier to review the commits one by one because the indentation makes the diff look more crazy than it is.

### Issue

https://github.com/hugo-toha/toha/issues/224

Doesn't solve that issue completly as it is about the footer _and the navbar_. The navbar was a bit over my head at this moment.

### Description

Allows to disable/enable parts of the footer (or all of the footer).

### Test Evidence

#### Footer disabled

![Screenshot_2021-04-28_12:59:29](https://user-images.githubusercontent.com/3586246/116393194-9dd06700-a821-11eb-99ad-716141a3b2a0.png)

#### Navigation disabled

![Screenshot_2021-04-28_12:58:53](https://user-images.githubusercontent.com/3586246/116393203-a0cb5780-a821-11eb-8a16-40133f59e2de.png)

#### Footer enabled, but all parts of it disabled

![Screenshot_2021-04-28_12:58:14](https://user-images.githubusercontent.com/3586246/116393208-a163ee00-a821-11eb-9029-c161ad8eee30.png)

#### Copyright notice disabled
![Screenshot_2021-04-28_13:01:28](https://user-images.githubusercontent.com/3586246/116393433-e6882000-a821-11eb-811e-43cf5e51ecb2.png)
