### PR TITLE
Disable logo by default + add logo only if the user provide it

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,3 +1,5 @@
+{{ $logoEnabled   := site.Params.logo.enable  | default false }}
+
 {{/* default favicon */}}
 {{ $favicon := "/images/favicon.png" }}
 
@@ -28,5 +30,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
-<!--================= fav-icon =========================-->
-<link rel="icon" type="image/png" href="{{ $favicon }}" />
+<!--================= fab-icon =========================-->
+{{ if $logoEnabled }}
+  <link rel="icon" type="image/png" href="{{ $favicon }}" />
+{{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,9 +13,6 @@
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
-<!--================= custom style overrides =========================-->
-<link rel="stylesheet" href="{{ "/css/style.css" | relURL }}"/>
-
 <!--================= fab-icon =========================-->
 {{/* add favicon only if the site author has provided the the favicon */}}
 {{ if site.Params.logo.favicon }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,20 +1,3 @@
-{{ $logoEnabled   := site.Params.logo.enable  | default false }}
-
-{{/* default favicon */}}
-{{ $favicon := "/images/favicon.png" }}
-
-{{/* if favicon is provided in the config, then use that */}}
-{{ if site.Params.logo.favicon }}
-  {{ $favicon = site.Params.logo.favicon }}
-{{ end }}
-
-{{/* resize the favicon. don't resize svg because it is not supported */}}
-{{ $favicon := resources.Get $favicon }}
-{{ if and $favicon (ne $favicon.MediaType.SubType "svg") }}
-  {{ $favicon = $favicon.Resize "42x" }}
-{{ end }}
-{{ $favicon = $favicon.RelPermalink}}
-
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="X-UA-Compatible" content="ie=edge" />
@@ -30,7 +13,20 @@
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@300;400;500;600" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
+<!--================= custom style overrides =========================-->
+<link rel="stylesheet" href="{{ "/css/style.css" | relURL }}"/>
+
 <!--================= fab-icon =========================-->
-{{ if $logoEnabled }}
+{{/* add favicon only if the site author has provided the the favicon */}}
+{{ if site.Params.logo.favicon }}
+  {{ $favicon := site.Params.logo.favicon }}
+
+  {{/* resize the favicon. don't resize svg because it is not supported */}}
+  {{ $favicon = resources.Get $favicon }}
+  {{ if and $favicon (ne $favicon.MediaType.SubType "svg") }}
+    {{ $favicon = $favicon.Resize "42x" }}
+  {{ end }}
+  {{ $favicon = $favicon.RelPermalink}}
+
   <link rel="icon" type="image/png" href="{{ $favicon }}" />
 {{end}}

--- a/layouts/partials/navigators/navbar-2.html
+++ b/layouts/partials/navigators/navbar-2.html
@@ -1,30 +1,31 @@
-{{ $logoEnabled   := site.Params.logo.enable  | default false }}
+{{/* by default don't use any logo */}}
+{{ $mainLogo := "" }}
+{{ $invertedLogo := "" }}
 
-{{/* default logos  */}}
-{{ $mainLogo := "/images/main-logo.png" }}
-{{ $invertedLogo := "/images/inverted-logo.png" }}
-
-{{/* if custom logo has been provided in the config file, then use them */}}
+{{/*  if custom logo has been provided, use them  */}}
 {{ if site.Params.logo.main }}
   {{ $mainLogo = site.Params.logo.main }}
 {{ end }}
-
 {{ if site.Params.logo.inverted }}
   {{ $invertedLogo = site.Params.logo.inverted }}
 {{ end }}
 
 {{/* resize the logos. don't resize svg because it is not supported */}}
-{{ $mainLogo := resources.Get $mainLogo}}
-{{ if and $mainLogo (ne $mainLogo.MediaType.SubType "svg") }}
-  {{ $mainLogo = $mainLogo.Resize "42x" }}
+{{ if $mainLogo }}
+  {{ $mainLogo = resources.Get $mainLogo}}
+  {{ if and $mainLogo (ne $mainLogo.MediaType.SubType "svg") }}
+    {{ $mainLogo = $mainLogo.Resize "42x" }}
+  {{ end }}
+  {{ $mainLogo = $mainLogo.RelPermalink}}
 {{ end }}
-{{ $mainLogo = $mainLogo.RelPermalink}}
 
-{{ $invertedLogo := resources.Get $invertedLogo}}
-{{ if and $invertedLogo (ne $invertedLogo.MediaType.SubType "svg") }}
-  {{ $invertedLogo = $invertedLogo.Resize "42x" }}
+{{ if $invertedLogo }}
+  {{ $invertedLogo = resources.Get $invertedLogo}}
+  {{ if and $invertedLogo (ne $invertedLogo.MediaType.SubType "svg")}}
+    {{ $invertedLogo = $invertedLogo.Resize "42x" }}
+  {{ end }}
+  {{ $invertedLogo = $invertedLogo.RelPermalink}}
 {{ end }}
-{{ $invertedLogo = $invertedLogo.RelPermalink}}
 
 <nav class="navbar navbar-expand-xl top-navbar final-navbar shadow">
   <div class="container">
@@ -32,7 +33,7 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
-      {{ if $logoEnabled }}
+      {{ if $mainLogo }}
         <img src="{{ $mainLogo  }}" alt="Logo">
       {{ end }}
       {{- site.Title -}}
@@ -49,9 +50,11 @@
       </ul>
     </div>
   </div>
-  {{ if $logoEnabled }}
-    <!-- Store the logo information in a hidden img for the JS -->
-    <img src="{{ $mainLogo  }}" class="d-none" id="main-logo" alt="Logo">
-    <img src="{{ $invertedLogo  }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
+  <!-- Store the logo information in a hidden img for the JS -->
+  {{ if $mainLogo }}
+    <img src="{{ $mainLogo }}" class="d-none" id="main-logo" alt="Logo">
+  {{ end }}
+  {{ if $invertedLogo }}
+    <img src="{{ $invertedLogo }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
   {{ end }}
 </nav>

--- a/layouts/partials/navigators/navbar-2.html
+++ b/layouts/partials/navigators/navbar-2.html
@@ -1,3 +1,5 @@
+{{ $logoEnabled   := site.Params.logo.enable  | default false }}
+
 {{/* default logos  */}}
 {{ $mainLogo := "/images/main-logo.png" }}
 {{ $invertedLogo := "/images/inverted-logo.png" }}
@@ -30,7 +32,9 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
-      <img src="{{ $mainLogo  }}" alt="Logo">
+      {{ if $logoEnabled }}
+        <img src="{{ $mainLogo  }}" alt="Logo">
+      {{ end }}
       {{- site.Title -}}
     </a>
     <button class="navbar-toggler navbar-light" id="toc-toggler" type="button" onclick="toggleTOC()">
@@ -45,7 +49,9 @@
       </ul>
     </div>
   </div>
-  <!-- Store the logo information in a hidden img for the JS -->
-  <img src="{{ $mainLogo  }}" class="d-none" id="main-logo" alt="Logo">
-  <img src="{{ $invertedLogo  }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
+  {{ if $logoEnabled }}
+    <!-- Store the logo information in a hidden img for the JS -->
+    <img src="{{ $mainLogo  }}" class="d-none" id="main-logo" alt="Logo">
+    <img src="{{ $invertedLogo  }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
+  {{ end }}
 </nav>

--- a/layouts/partials/navigators/navbar-2.html
+++ b/layouts/partials/navigators/navbar-2.html
@@ -1,4 +1,4 @@
-{{/* by default don't use any logo */}}
+{{/* by default, don't use any logo */}}
 {{ $mainLogo := "" }}
 {{ $invertedLogo := "" }}
 

--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -1,6 +1,7 @@
 {{/*  variables for enabling/disabling various features  */}}
 {{ $blogEnabled   := site.Params.features.blog.enable   | default false }}
 {{ $notesEnabled  := site.Params.features.notes.enable  | default false }}
+{{ $logoEnabled   := site.Params.logo.enable            | default false }}
 
 {{/*  keep backward compatibility for blog post  */}}
 {{ if site.Params.enableBlogPost }}
@@ -45,7 +46,9 @@
 <nav class="navbar navbar-expand-xl top-navbar initial-navbar" id="top-navbar">
   <div class="container">
     <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
-      <img src="{{ $invertedLogo }}" id="logo" alt="Logo">
+      {{ if $logoEnabled }}
+        <img src="{{ $invertedLogo }}" id="logo" alt="Logo">
+      {{ end }}
       {{- site.Title -}}
     </a>
     <button
@@ -118,7 +121,9 @@
       </ul>
     </div>
   </div>
-  <!-- Store the logo information in a hidden img for the JS -->
-  <img src="{{ $mainLogo }}" class="d-none" id="main-logo" alt="Logo">
-  <img src="{{ $invertedLogo }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
+  {{ if $logoEnabled }}
+    <!-- Store the logo information in a hidden img for the JS -->
+    <img src="{{ $mainLogo }}" class="d-none" id="main-logo" alt="Logo">
+    <img src="{{ $invertedLogo }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
+  {{ end }}
 </nav>

--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -1,18 +1,17 @@
 {{/*  variables for enabling/disabling various features  */}}
 {{ $blogEnabled   := site.Params.features.blog.enable   | default false }}
 {{ $notesEnabled  := site.Params.features.notes.enable  | default false }}
-{{ $logoEnabled   := site.Params.logo.enable            | default false }}
 
 {{/*  keep backward compatibility for blog post  */}}
 {{ if site.Params.enableBlogPost }}
   {{ $blogEnabled = true }}
 {{ end }}
 
-{{/*  default logos  */}}
-{{ $mainLogo := "/images/main-logo.png" }}
-{{ $invertedLogo := "/images/inverted-logo.png" }}
+{{/* by default don't use any logo */}}
+{{ $mainLogo := "" }}
+{{ $invertedLogo := "" }}
 
-{{/*  if custom logo is used, them  */}}
+{{/*  if custom logo has been provided, use them  */}}
 {{ if site.Params.logo.main }}
   {{ $mainLogo = site.Params.logo.main }}
 {{ end }}
@@ -21,17 +20,21 @@
 {{ end }}
 
 {{/* resize the logos. don't resize svg because it is not supported */}}
-{{ $mainLogo := resources.Get $mainLogo}}
-{{ if and $mainLogo (ne $mainLogo.MediaType.SubType "svg") }}
-  {{ $mainLogo = $mainLogo.Resize "42x" }}
+{{ if $mainLogo }}
+  {{ $mainLogo = resources.Get $mainLogo}}
+  {{ if and $mainLogo (ne $mainLogo.MediaType.SubType "svg") }}
+    {{ $mainLogo = $mainLogo.Resize "42x" }}
+  {{ end }}
+  {{ $mainLogo = $mainLogo.RelPermalink}}
 {{ end }}
-{{ $mainLogo = $mainLogo.RelPermalink}}
 
-{{ $invertedLogo := resources.Get $invertedLogo}}
-{{ if and $invertedLogo (ne $invertedLogo.MediaType.SubType "svg")}}
-  {{ $invertedLogo = $invertedLogo.Resize "42x" }}
+{{ if $invertedLogo }}
+  {{ $invertedLogo = resources.Get $invertedLogo}}
+  {{ if and $invertedLogo (ne $invertedLogo.MediaType.SubType "svg")}}
+    {{ $invertedLogo = $invertedLogo.Resize "42x" }}
+  {{ end }}
+  {{ $invertedLogo = $invertedLogo.RelPermalink}}
 {{ end }}
-{{ $invertedLogo = $invertedLogo.RelPermalink}}
 
 {{ $customMenus := site.Params.customMenus }}
 {{ if (index site.Data site.Language.Lang).site.customMenus }}
@@ -46,7 +49,7 @@
 <nav class="navbar navbar-expand-xl top-navbar initial-navbar" id="top-navbar">
   <div class="container">
     <a class="navbar-brand" href="{{ site.BaseURL | relLangURL }}">
-      {{ if $logoEnabled }}
+      {{ if $invertedLogo }}
         <img src="{{ $invertedLogo }}" id="logo" alt="Logo">
       {{ end }}
       {{- site.Title -}}
@@ -121,9 +124,11 @@
       </ul>
     </div>
   </div>
-  {{ if $logoEnabled }}
-    <!-- Store the logo information in a hidden img for the JS -->
+  <!-- Store the logo information in a hidden img for the JS -->
+  {{ if $mainLogo }}
     <img src="{{ $mainLogo }}" class="d-none" id="main-logo" alt="Logo">
+  {{ end }}
+  {{ if $invertedLogo }}
     <img src="{{ $invertedLogo }}" class="d-none" id="inverted-logo" alt="Inverted Logo">
   {{ end }}
 </nav>

--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -7,7 +7,7 @@
   {{ $blogEnabled = true }}
 {{ end }}
 
-{{/* by default don't use any logo */}}
+{{/* by default, don't use any logo */}}
 {{ $mainLogo := "" }}
 {{ $invertedLogo := "" }}
 

--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -16,8 +16,12 @@
         $('#navbar-toggler').addClass('navbar-light');
 
         // get the main logo from hidden img tag
-        let mainLogo = document.getElementById("main-logo").getAttribute("src");
-        $('#logo').attr("src", mainLogo);
+        let mainLogo = document.getElementById("main-logo")
+        if (mainLogo !== null) {
+          let logoURL = mainLogo.getAttribute("src");
+          $('#logo').attr("src", logoURL);
+        }
+
       } else {
         $('#top-navbar').removeClass('final-navbar shadow');
         $('#top-navbar').addClass('initial-navbar');
@@ -26,8 +30,11 @@
         $('#navbar-toggler').addClass('navbar-dark');
 
         // get the inverted logo from hidden img tag
-        let invertedLogo = document.getElementById("inverted-logo").getAttribute("src");
-        $('#logo').attr("src", invertedLogo);
+        let invertedLogo = document.getElementById("inverted-logo")
+        if (invertedLogo !== null) {
+          let logoURL = invertedLogo.getAttribute("src");
+          $('#logo').attr("src", logoURL);
+        }
       }
     });
 


### PR DESCRIPTION
### Issue
There is no related issue.

### Description

Logos are not shown by default. (I figured this is a sensible default because most people don't have a personal logo. Especially not in different light/dark version. But I would be happy to discuss this point.

Logos can be enabled again with (toml)

```toml
[params.logo]
enable = true
```

or (yaml)

```yaml
params.logo.enable: true
```
### Test Evidence

<img width="1571" alt="no_logo" src="https://user-images.githubusercontent.com/3586246/120317163-95ff5900-c2de-11eb-845d-2fdf50118169.png">
