### PR TITLE
Fix horizontal scrollbar when skill section active

### DIFF
--- a/static/css/sections/about.css
+++ b/static/css/sections/about.css
@@ -496,6 +496,11 @@
   .about-section.container {
     max-width: 100%;
   }
+
+  .circular-progress {
+    width: 140px;
+    height: 140px;
+  }
 }
 
 /* Small devices (landscape phones, 576px and up) */


### PR DESCRIPTION
### Issue
[here](https://github.com/hugo-toha/toha/issues/304)

### Description

Make the card max-width 5% lower to respect the space it  have, and avoid the appear of the horizontal scrollbar.

### Test Evidence
Evidences on the issue.