### PR TITLE
Support Google Analytics v4

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,7 +11,7 @@
 
     <!-- ADD GOOGLE ANALYTICS IF ENABLED -->
     {{ if site.GoogleAnalytics }}
-      {{ template "_internal/google_analytics_async.html" . }}
+      {{ template "_internal/google_analytics.html" . }}
     {{ end }}
   </head>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
     
     <!-- Add Google Analytics if enabled in configuration -->
     {{ if site.GoogleAnalytics }}
-        {{ template "_internal/google_analytics_async.html" . }}
+        {{ template "_internal/google_analytics.html" . }}
     {{ end }}
   </head>
   <body data-spy="scroll" data-target="#top-navbar" data-offset="100">


### PR DESCRIPTION
Per [Issue #352 ](https://github.com/hugo-toha/toha/issues/352): in order to support Google Analytics v4, _internal/google_analytics.html should be used

Fixes #352 