### PR TITLE
Remove about section whitespace when there are no soft skills/badges

### DIFF
--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -11,8 +11,8 @@
 <div class="container anchor p-lg-5 about-section" id="{{ $sectionID }}">
   <div class="row pt-sm-2 pt-md-4 align-self-center">
     <!-- summary -->
-    <!-- takes up full section width if no soft skills are specified -->
-    {{ if .softSkills }} <div class="col-sm-6"> {{ else }} <div class="col-sm-12"> {{ end }}
+    <!-- takes up full section width if no badges/soft skills are specified -->
+    {{ if or (.softSkills) (.badges) }} <div class="col-sm-6"> {{ else }} <div class="col-sm-12"> {{ end }}
       <h3 class="p-1">{{ $author.name }}</h3>
       {{ if .designation }}
       <h5 class="p-1">

--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -11,7 +11,8 @@
 <div class="container anchor p-lg-5 about-section" id="{{ $sectionID }}">
   <div class="row pt-sm-2 pt-md-4 align-self-center">
     <!-- summary -->
-    <div class="col-sm-6">
+    <!-- takes up full section width if no soft skills are specified -->
+    {{ if .softSkills }} <div class="col-sm-6"> {{ else }} <div class="col-sm-12"> {{ end }}
       <h3 class="p-1">{{ $author.name }}</h3>
       {{ if .designation }}
       <h5 class="p-1">


### PR DESCRIPTION
### Issue
Closes #368. The about section summary will now take up the entire section width when no soft skills/badges are specified in `about.yaml`

### Description

This PR adds a conditional statement that checks whether soft skills (indicated by `softSkills` in `about.yaml`) or badges (indicated by `badges`) have been specified by the user. If there are soft skills/badges, the original `col-sm-6` style is applied. However, when there are no soft skills, `col-sm-12` is applied instead — indicating that the summary should take up the full width of the section. 

### Test Evidence

I tested all changes locally using Firefox 89.0.2. Formatting when soft skills are specified, badges are specified, or both remain unchanged across both desktop and mobile versions of the site. When neither soft skills nor badges are specified, the about section summary takes up the entire width on both desktop and mobile versions of the site. All other formatting remains unchanged. 

![aboutr_section_without_whitespace](https://user-images.githubusercontent.com/23201789/124367947-e2f18a80-dc10-11eb-9eac-1184bf827182.png)

The summary also displays correctly on Chrome and Edge. 



 

