### PR TITLE
Added svg support for project icons

### DIFF
--- a/layouts/partials/cards/project.html
+++ b/layouts/partials/cards/project.html
@@ -11,7 +11,10 @@
 
             {{ $logoImage:= resources.Get .logo}}
             {{ if $logoImage }}
-            {{ $logoImage = $logoImage.Fit "24x24" }}
+            {{/*  svg don't support "Fit" operation   */}}
+            {{ if ne $logoImage.MediaType.SubType "svg" }}
+              {{ $logoImage = $logoImage.Fit "24x24" }}
+            {{ end }}
 
             <img class="card-img-xs" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
             {{ end }}


### PR DESCRIPTION
### Issue
Fixes: https://github.com/hugo-toha/toha/issues/375

### Description

Handles SVGs for logos in the project card template by only calling the fit function if the icon is not an SVG

### Test Evidence

![image](https://user-images.githubusercontent.com/7625470/125740738-b764eb41-f29a-44cc-953f-cd9e2753530e.png)
