### PR TITLE
education-line

### DIFF
--- a/static/css/sections/education.css
+++ b/static/css/sections/education.css
@@ -36,7 +36,7 @@
 }
 
 .education-section .education-info-table tr:first-child .hline {
-  height: 60%;
+  height: 65%;
   top: auto;
 }
 


### PR DESCRIPTION
### Issue
Fixes #381

### Description

Slightly increases the hline element on the first item to hide the gap present.

### Test Evidence

![image](https://user-images.githubusercontent.com/1520296/128633916-f82f63a4-1f93-44b0-aaff-c1c255dacd03.png)