### PR TITLE
Allow setting GIFS as author image

### DIFF
--- a/layouts/partials/helpers/get-author-image.html
+++ b/layouts/partials/helpers/get-author-image.html
@@ -18,12 +18,12 @@
     {{ end }}
 {{ end }}
 
-{{/* apply image processing. don't use "Fit" in svg because its not supported */}}
+{{/* apply image processing. don't use "Fit" in svg or gif because its not supported */}}
 {{ $authorImage:= resources.Get $authorImage}}
-{{ if and $authorImage (ne $authorImage.MediaType.SubType "svg") }}
+
+{{ if and $authorImage (and (ne $authorImage.MediaType.SubType "svg") ( ne $authorImage.MediaType.SubType "gif")) }}
   {{ $authorImage = $authorImage.Fit "120x120" }}
 {{ end }}
 
 {{/*  return the author image link  */}}
 {{ return $authorImage.RelPermalink }}
-

--- a/layouts/partials/sections/home.html
+++ b/layouts/partials/sections/home.html
@@ -26,8 +26,11 @@
   {{ $authorImage = $author.image }}
 {{ end }}
 {{ $authorImage := resources.Get $authorImage }}
-{{ $authorImage = $authorImage.Fit "148x148" }}
 
+{{/* apply image processing. don't use "Fit" in svg or gif because its not supported */}}
+{{ if and $authorImage (and (ne $authorImage.MediaType.SubType "svg") ( ne $authorImage.MediaType.SubType "gif")) }}
+  {{ $authorImage = $authorImage.Fit "148x148" }}
+{{ end }}
 {{/* get file that matches the filename as specified as src="" in shortcode */}}
 {{ $src := resources.Get $backgroundImage }}
 


### PR DESCRIPTION
### Issue
fixes hugo-toha/toha#392
fixes hugo-toha/toha#209

### Description

allow_gifs -  don't apply image processing to svg or gif

### Test Evidence

Add a gif as a author image, and make sure it displays as expected on home page as well as single posts or anywhere else the author image is used.