### PR TITLE
taxonomies -  added taxonmies support

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -8,6 +8,12 @@ other = "Posts"
 [toc_heading]
 other = "Table of Contents"
 
+[tags]
+other = "Tags"
+
+[categories]
+other = "Categories"
+
 [at]
 other = "at"
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -54,7 +54,15 @@
         <div class="title">
           <h1>{{ .Page.Title }}</h1>
         </div>
-
+        {{ if site.Params.enableTags }}
+        <div class="taxonomy-terms">
+            <ul class="taxonomy-terms">
+            {{ range .Params.tags }}
+            <li><a href="/tags/{{ . | urlize }}"><span class="tag-item">{{ . }}</span></a></li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
         <div class="post-content" id="post-content">
           {{ .Page.Content }}
         </div>

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -1,0 +1,62 @@
+{{ define "header" }}
+    <link rel="stylesheet" href="{{ "/css/layouts/list.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "/css/navigators/sidebar.css" | relURL}}">
+    <!--================= custom style overrides =========================-->
+    <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}"/>
+
+{{ end }}
+
+{{ define "navbar" }}
+    {{ partial "navigators/navbar-2.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}
+  {{ $homePage:="#" }}
+  {{ if site.IsMultiLingual }}
+    {{ $homePage = (path.Join (cond ( eq .Language.Lang "en") "" .Language.Lang) .Type) }}
+  {{ end }}
+
+  <section class="sidebar-section" id="sidebar-section">
+    <div class="sidebar-holder">
+      <div class="sidebar" id="sidebar">
+        <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
+          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+        </form>
+        <div class="sidebar-tree">
+          <ul class="tree" id="tree">
+            <li id="list-heading"><a href="{{ .Type | relLangURL }}" data-filter="all">{{ i18n .Type }}</a></li>
+            <div class="subtree taxonomy-terms">
+              {{ $context := . }}
+              {{ partial "navigators/taxonomies.html" (dict "context" $context "taxo" "categories" "title" ( humanize "categories" ) ) }}
+            </div>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content container-fluid" id="content">
+    <div class="container-fluid post-card-holder" id="post-card-holder">
+      {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
+      {{ $paginator := .Paginate $posts 12 }}
+      {{ range $paginator.Pages }}
+        {{ if .Layout }}
+          {{/* ignore the search.md file*/}}
+        {{ else }}
+          {{ partial "cards/post.html" . }}
+        {{ end }}
+      {{ end }}
+    </div>
+    <div class="paginator">
+      {{ template "_internal/pagination.html" . }}
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{ define "scripts" }}
+    <script src="{{ "/js/list.js" | relURL }}"></script>
+{{ end }}

--- a/layouts/partials/navigators/taxonomies.html
+++ b/layouts/partials/navigators/taxonomies.html
@@ -1,0 +1,11 @@
+{{ $context := .context  }}
+{{ $taxo := .taxo  }}
+{{ $title := .title  }}
+{{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
+  {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
+  {{ if (gt (len $taxonomy) 0)}}
+        {{ range $taxonomy }}
+          <li><a class="taxonomy-term" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
+        {{ end }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/navigators/taxonomies.html
+++ b/layouts/partials/navigators/taxonomies.html
@@ -1,11 +1,15 @@
 {{ $context := .context  }}
 {{ $taxo := .taxo  }}
 {{ $title := .title  }}
+{{ $class:= "" }}
 {{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
   {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
   {{ if (gt (len $taxonomy) 0)}}
         {{ range $taxonomy }}
-          <li><a class="taxonomy-term" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
+          {{if eq $context.Title .Page.Title}}
+            {{ $class = "active" }}
+          {{end}}
+          <li><a class="taxonomy-term {{ $class }}" href="{{ .Page.Permalink }}" data-taxonomy-term="{{ urlize .Page.Title }}"><span class="taxonomy-label">{{ .Page.Title }}</span></a></li>
         {{ end }}
   {{ end }}
 {{ end }}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -1,0 +1,62 @@
+{{ define "header" }}
+    <link rel="stylesheet" href="{{ "/css/layouts/list.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "/css/navigators/sidebar.css" | relURL}}">
+    <!--================= custom style overrides =========================-->
+    <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}"/>
+
+{{ end }}
+
+{{ define "navbar" }}
+    {{ partial "navigators/navbar-2.html" . }}
+{{ end }}
+
+{{ define "sidebar" }}
+  {{ $homePage:="#" }}
+  {{ if site.IsMultiLingual }}
+    {{ $homePage = (path.Join (cond ( eq .Language.Lang "en") "" .Language.Lang) .Type) }}
+  {{ end }}
+
+  <section class="sidebar-section" id="sidebar-section">
+    <div class="sidebar-holder">
+      <div class="sidebar" id="sidebar">
+        <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
+          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+        </form>
+        <div class="sidebar-tree">
+          <ul class="tree" id="tree">
+            <li id="list-heading"><a href="{{ .Type | relLangURL }}" data-filter="all">{{ i18n .Type }}</a></li>
+            <div class="subtree taxonomy-terms">
+              {{ $context := . }}
+              {{ partial "navigators/taxonomies.html" (dict "context" $context "taxo" "tags" "title" ( humanize "tags" ) ) }}
+            </div>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}
+
+{{ define "content" }}
+<section class="content-section" id="content-section">
+  <div class="content container-fluid" id="content">
+    <div class="container-fluid post-card-holder" id="post-card-holder">
+      {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
+      {{ $paginator := .Paginate $posts 12 }}
+      {{ range $paginator.Pages }}
+        {{ if .Layout }}
+          {{/* ignore the search.md file*/}}
+        {{ else }}
+          {{ partial "cards/post.html" . }}
+        {{ end }}
+      {{ end }}
+    </div>
+    <div class="paginator">
+      {{ template "_internal/pagination.html" . }}
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{ define "scripts" }}
+    <script src="{{ "/js/list.js" | relURL }}"></script>
+{{ end }}

--- a/static/css/layouts/single.css
+++ b/static/css/layouts/single.css
@@ -236,6 +236,38 @@ h6 {
 #scroll-to-top.show {
   visibility: visible;
 }
+.taxonomy-terms {
+  text-align: center;
+}
+.taxonomy-terms li {
+  font-size: .8em;
+  list-style-type: none;
+  display: inline-block;
+  padding: .5em;
+  min-width: 5em;
+  margin: 0 .5em;
+	position: relative;
+	background: #8dd6dd;
+	border-radius: .4em;
+}
+
+.taxonomy-terms li:after {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 50%;
+	width: 0;
+	height: 0;
+	border: 10px solid transparent;
+	border-right-color: #8dd6dd;
+	border-left: 0;
+	margin-top: -10px;
+	margin-left: -10px;
+}
+
+.taxonomy-terms a{
+  color: black;
+}
 
 /* ============= Device specific fixes ======= */
 


### PR DESCRIPTION
### Issue
I saw the issue hugo-toha/guide#34 and thought it would be a nice addition.

### Description

This adds support to enable a tag list underneath the title of a post as well as list pages and sidebars to show tags and categories. I was unable to figure out how to get a box underneath TOC to display categories. I got close, but it just showed as a big white blob of an area and made them look like they were in the same box. 

The tags underneath the title could use some work, but I am not that good at css, so feel free to give feedback.

### Test Evidence
![image](https://user-images.githubusercontent.com/1520296/129482756-15e55779-2838-4188-89c7-9360e13d7fc1.png)
![image](https://user-images.githubusercontent.com/1520296/129482792-3059c729-0f36-4627-b2f0-abccc8b002d9.png)