### PR TITLE
Add Blogtrottr as newsletter provider

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -121,13 +121,13 @@
                 <button type="submit" class="btn btn-info">{{ i18n "submit" }}</button>
               </form>
             {{ else }}
-             <!-- a dummy form -->
-              <form>
-                <div class="form-group">
-                  <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="{{ i18n "newsletter_input_placeholder" }}"/>
-                  <small id="emailHelp" class="form-text text-muted">{{ i18n "newsletter_warning" }}</small>
-                </div>
-                <button type="submit" class="btn btn-info">{{ i18n "submit" }}</button>
+              <form method='post' action='https://blogtrottr.com'>
+              <div class="form-group">
+              <input type='email' class="form-control" name='btr_email' placeholder="{{ i18n "newsletter_input_placeholder" }}"/><br />
+              <input type='hidden' name='btr_url' value='{{ "" | absLangURL }}index.xml' />
+              <input type='hidden' name='schedule_type' value='1' />
+              <small id="emailHelp" class="form-text text-muted">{{ i18n "newsletter_warning" }}</small>
+              <button type="submit" class="btn btn-info"> {{ i18n "submit" }} </button>
               </form>
             {{ end }}
           </div>


### PR DESCRIPTION
### Issue
 Might be related to issue  #35 (Newsletter functionality), although already solved

### Description

Hi! I was thinking of adding blogtrottr support to the theme's newsletter functionality, so that the default box works and is not just a dummy form. Blogtrottr is an RSS -> email service that automatically scans an RSS feed in search of updates from time to time and sends these updates in the form of an email to the user. As it works out of the box, it wouldnt need to get configured to get going, as is necessary, for example, with mailchimp.

Of course, it could be added as just another option by adding an else if statement; I just thought it was neater this way.

### Test Evidence

![blogtrottr](https://user-images.githubusercontent.com/48572431/131232278-057ed28f-a1cc-4e50-a148-95d86a0be2d3.png)
 
At work on my personal website. As it is not live, no feed is detected (localhost only as I used absLangURL). Note that you can subscribe to a different feed for each language in the website