### PR TITLE
Added new 'GitForge' param for non GitHub repos

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -71,7 +71,13 @@
         <!--- Improve this page button --->
         {{ if site.Params.GitRepo }}
           <div class="btn-improve-page">
-              <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+            {{ if ( eq site.Params.GitForge "gitlab" ) }}
+              <a href="{{ site.Params.GitRepo }}-/edit/{{ site.Params.GitBranch }}/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+            {{ else if ( eq site.Params.GitForge "gitea" ) }}
+              <a href="{{ site.Params.GitRepo }}_edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+            {{ else }} <!--- Make Github-style the default -->
+               <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+            {{ end }}
                 <i class="fas fa-code-branch"></i>
                 {{ i18n "improve_this_page" }}
               </a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -70,13 +70,18 @@
 
         <!--- Improve this page button --->
         {{ if site.Params.GitRepo }}
+          {{ if site.Params.GitBranch }}
+            {{ .Scratch.Set "GitBranch" site.Params.GitBranch }}
+          {{ else }}
+            {{ .Scratch.Set "GitBranch" "main" }}
+          {{ end }}
           <div class="btn-improve-page">
             {{ if ( eq site.Params.GitForge "gitlab" ) }}
-              <a href="{{ site.Params.GitRepo }}-/edit/{{ site.Params.GitBranch }}/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+              <a href="{{ site.Params.GitRepo }}/-/edit/{{ .Scratch.Get "GitBranch" }}/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
             {{ else if ( eq site.Params.GitForge "gitea" ) }}
-              <a href="{{ site.Params.GitRepo }}_edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+              <a href="{{ site.Params.GitRepo }}/_edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
             {{ else }} <!--- Make Github-style the default -->
-               <a href="{{ site.Params.GitRepo }}/edit/{{ site.Params.GitBranch }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
+               <a href="{{ site.Params.GitRepo }}/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}" title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
             {{ end }}
                 <i class="fas fa-code-branch"></i>
                 {{ i18n "improve_this_page" }}


### PR DESCRIPTION
### Issue
I use a gitea repository; with the current setup, there is no way to use it with toha

### Description

Makes the"Improve this page" button compatible with gitea and gitlab repos, while keeping backwards compatibility, I also tried to establish "main" as the default branch by doing: 
`
{{ if site.Params.GitBranch }}
  {{ $GitBranch = site.Params.GitBranch }}
{{ else }}
    {{ $GitBranch = main }}
{{ end }}

`

But I couldnt get it to work