### PR TITLE
Corrected the word "Details" and another minor capitalization change.

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -18,7 +18,7 @@ other = "Catégories"
 other = "chez"
 
 [resume]
-other = "Mon Curriculum vitæ"
+other = "Mon Curriculum Vitæ"
 
 [navigation]
 other = "Navigation"
@@ -102,7 +102,7 @@ other = "Lire"
 # other = "Star"
 
 # [project_details]
-# other = "Details"
+# other = "Détails"
 
 # [err_404]
 # other = "The page you are looking for is not there yet."

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -101,8 +101,8 @@ other = "Lire"
 # [project_star]
 # other = "Star"
 
-# [project_details]
-# other = "Détails"
+[project_details]
+other = "Détails"
 
 # [err_404]
 # other = "The page you are looking for is not there yet."


### PR DESCRIPTION
### Issue
Typos in the French version

### Description

Corrected a typo in the word "Details". The French version should have an "é" with a diacritic instead of a plain "e".
Also capitalized "vitæ" in the phrase "Mon Curriculum Vitæ".