### PR TITLE
Corrected the word "Details" and another minor capitalization change.

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -18,7 +18,7 @@ other = "Catégories"
 other = "chez"
 
 [resume]
-other = "Mon Curriculum vitæ"
+other = "Mon Curriculum Vitæ"
 
 [navigation]
 other = "Navigation"
@@ -102,7 +102,7 @@ other = "Lire"
 # other = "Star"
 
 # [project_details]
-# other = "Details"
+# other = "Détails"
 
 # [err_404]
 # other = "The page you are looking for is not there yet."

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -101,8 +101,8 @@ other = "Lire"
 # [project_star]
 # other = "Star"
 
-# [project_details]
-# other = "Détails"
+[project_details]
+other = "Détails"
 
 # [err_404]
 # other = "The page you are looking for is not there yet."


### PR DESCRIPTION
### Issue
Typos in the French version + French translation for the word "Details" is commented out.

### Description
Corrected a typo in the word "Details". The French version should have an "é" with a diacritic instead of a plain "e".
I uncommented the relevant parts so that the French version of the website will show the correct French translation.

I also capitalized "vitæ" in the phrase "Mon Curriculum Vitæ".

### Test

#### Before the changes
Going to the project section of the French version defaults to the English version of the word "Details".

#### After the changes
Testing the project section of the French version after enabling the changes shows the word "Détails" in French which is the desired behavior.
