### PR TITLE
Footer contact info: Icons and linking

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -87,20 +87,21 @@
           <ul>
             {{ range $key,$value:= $author.contactInfo }}
               {{ if (eq $key "email") }}
-                <li><a href={{ printf "mailto:%s" $value }}>
+                <li><a href={{ printf "mailto:%s" $value }} target="_blank" rel="noopener">
                   <span><i class="fas fa-envelope"></i></span> <span>{{ $value }}</span>
                 </a></li>
+              {{ else if (eq $key "phone") }}
+                <li><span><i class="fas fa-phone-alt"></i></span> <span>{{ $value }}</span></li>
               {{ else if (eq $key "linkedin") }}
-                <li><a href={{ printf "https://www.linkedin.com/in/%s" $value }}>
+                <li><a href={{ printf "https://www.linkedin.com/in/%s" $value }} target="_blank" rel="noopener">
                   <span><i class="fab fa-linkedin"></i></span> <span>{{ $author.name }}</span>
                 </a></li>
               {{ else if (eq $key "github") }}
-                <li><a href={{ printf "https://github.com/%s" $value }}>
+                <li><a href={{ printf "https://github.com/%s" $value }} target="_blank" rel="noopener">
                   <span><i class="fab fa-github"></i></span> <span>{{ $value }}</span>
                 </a></li>
               {{ else }}
                 <li><span>{{ title $key }}: </span> <span>{{ $value }}</span></li>
-              {{ end }}
               {{ end }}
             {{ end }}
           </ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -37,7 +37,7 @@
 
   {{ $disclaimer := "" }}
   {{ $siteConfig := (index site.Data site.Language.Lang).site }}
-  {{ if $siteConfig.disclaimer }} 
+  {{ if $siteConfig.disclaimer }}
     {{ $disclaimer = $siteConfig.disclaimer }}
   {{ end }}
 
@@ -86,7 +86,22 @@
           <h5>{{ i18n "contact_me" }}</h5>
           <ul>
             {{ range $key,$value:= $author.contactInfo }}
-            <li><span>{{ title $key }}: </span> <span>{{ $value }}</span></li>
+              {{ if (eq $key "email") }}
+                <li><a href={{ printf "mailto:%s" $value }}>
+                  <span><i class="fas fa-envelope"></i></span> <span>{{ $value }}</span>
+                </a></li>
+              {{ else if (eq $key "linkedin") }}
+                <li><a href={{ printf "https://www.linkedin.com/in/%s" $value }}>
+                  <span><i class="fab fa-linkedin"></i></span> <span>{{ $author.name }}</span>
+                </a></li>
+              {{ else if (eq $key "github") }}
+                <li><a href={{ printf "https://github.com/%s" $value }}>
+                  <span><i class="fab fa-github"></i></span> <span>{{ $value }}</span>
+                </a></li>
+              {{ else }}
+                <li><span>{{ title $key }}: </span> <span>{{ $value }}</span></li>
+              {{ end }}
+              {{ end }}
             {{ end }}
           </ul>
         </div>


### PR DESCRIPTION
IMO this makes the contact info in the footer:

- Tidier, because the FA icons have a fixed width
- More user-friendly, as clicking a link is always easier than copy-pasting,
  searching, etc.

It's also easily extendable by slapping on another `else if`.
