### PR TITLE
Localize post date

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -48,7 +48,7 @@
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p>{{ .Page.Date.Format "January 2, 2006" }}</p>
+          <p>{{ .Page.Date | time.Format ":date_full" }}</p>
         </div>
 
         <div class="title">


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->

### Description

The post date will be displayed in its localized version even if the page is translated.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->
<img width="284" alt="Bildschirmfoto 2022-01-12 um 11 45 32" src="https://user-images.githubusercontent.com/9169222/149126803-ff755727-26a3-4209-99fe-fea419d7105e.png">
