### PR TITLE
Update skill.html

### DIFF
--- a/layouts/partials/cards/skill.html
+++ b/layouts/partials/cards/skill.html
@@ -2,15 +2,15 @@
   <a class="skill-card-link" {{ if .url }}href="{{ .url }}" title="{{ .name }}" target="_blank" rel="noopener"{{ end }}>
     <div class="card">
       <div class="card-head d-flex">
-        {{ if .logo }}
-          {{ $logoImage := resources.Get .logo }}
+        {{ if .icon }}
+          {{ $iconImage := resources.Get .icon }}
 
           {{/*  svg don't support "Fit" operation   */}}
-          {{ if ne $logoImage.MediaType.SubType "svg" }}
-            {{ $logoImage = $logoImage.Fit "24x24" }}
+          {{ if ne $iconImage.MediaType.SubType "svg" }}
+            {{ $iconImage = $iconImage.Fit "24x24" }}
           {{ end }}
 
-          <img class="card-img-xs" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+          <img class="card-img-xs" src="{{ $iconImage.RelPermalink }}" alt="{{ .name }}" />
         {{ end }}
         <h5 class="card-title">{{ .name }}</h5>
       </div>


### PR DESCRIPTION
Changed "logo" to "icon" to correspond to guide (https://github.com/hugo-toha/guides/blob/2359b494c7b768cb32ce468fe1047fc305d79898/content/posts/configuration/sections/skills/index.md?plain=1#L27)

### Issue
A set "icon" in `data/en/sections/skills.yaml` did not appear.

### Description
`layout/partials/cards/skill.html` expected "logo" instead of "icon".

Alternative solution: rename "icon" to "logo" in guide.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->