### PR TITLE
fix: navigation with hidden title

### DIFF
--- a/layouts/partials/sections/accomplishments.html
+++ b/layouts/partials/sections/accomplishments.html
@@ -6,9 +6,12 @@
 <div class="container-fluid anchor pb-5 accomplishments-section">
   {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
-      <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
-
+  
   <div class="container">
     <div class="row" id="acomplishment-card-holder">
       {{ range .accomplishments }}

--- a/layouts/partials/sections/achievements.html
+++ b/layouts/partials/sections/achievements.html
@@ -6,7 +6,10 @@
 <div class="container-fluid anchor pb-5 achievements-section">
   {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
-      <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
   <div class="container">
     <div class="row" id="gallery">

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -4,9 +4,13 @@
 {{ end }}
 
 <div class="container-fluid anchor pb-5 education-section education-alt" id="{{ $sectionID }}">
-    {{ if not (.section.hideTitle) }}
-    <h1 class="text-center">{{ .section.name }}</h1>
-    {{ end }}
+  {{ if not (.section.hideTitle) }}
+    <h1 class="text-center">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ end }}
 
     <div class="container">
         <table class="education-info-table">

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -4,10 +4,13 @@
 {{ end }}
 
 <div class="container-fluid anchor pb-5 education-section">
-    {{ if not (.section.hideTitle) }}
+  {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
         <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
-    {{ end }}
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ end }}
 
     <div class="container">
         <table class="education-info-table">

--- a/layouts/partials/sections/experiences.html
+++ b/layouts/partials/sections/experiences.html
@@ -6,8 +6,10 @@
 <div class="container-fluid anchor pb-5 experiences-section">
   {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
-      <span id="{{ $sectionID }}"></span>{{ .section.name }}
-    </h1>
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
 
   <div class="container timeline text-justify">

--- a/layouts/partials/sections/projects.html
+++ b/layouts/partials/sections/projects.html
@@ -5,7 +5,11 @@
 
 <div class="container-fluid anchor pb-5 projects-section" id="{{ $sectionID }}">
   {{ if not (.section.hideTitle) }}
-    <h1 class="text-center">{{ .section.name }}</h1>
+    <h1 class="text-center">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
   <div class="container ml-auto text-center">
     <div class="btn-group flex-wrap" role="group" id="project-filter-buttons">

--- a/layouts/partials/sections/recent-posts.html
+++ b/layouts/partials/sections/recent-posts.html
@@ -12,7 +12,10 @@
 <div class="container-fluid anchor pb-5 recent-posts-section">
   {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
-      <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
   <div class="container">
     <div class="row" id="recent-post-cards">

--- a/layouts/partials/sections/skills.html
+++ b/layouts/partials/sections/skills.html
@@ -6,7 +6,10 @@
 <div class="container-fluid anchor pb-5 skills-section">
   {{ if not (.section.hideTitle) }}
     <h1 class="text-center">
-      <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
+  {{ else }}
+    <h1 class="text-center" style="display: none">
+        <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
   <div class="container d-flex-block">
     <div class="row" id="primary-skills">


### PR DESCRIPTION
### Issue
Navigation didn't work when section title was hidden. Fixes #494

### Description
Implemented if conditional. If `hidetitle` is true, `display: none` will be set. Thus, the `.section.id` to navigate to is still in the html to be navigated to.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->