### PR TITLE
Tweaked background of table in education.css

### DIFF
--- a/static/css/sections/education.css
+++ b/static/css/sections/education.css
@@ -1,6 +1,7 @@
 .education-section .education-info-table {
   width: 100%;
   border: none;
+  background: none;
 }
 
 .education-section .education-info-table tr:hover {
@@ -12,6 +13,7 @@
 .education-section .education-info-table td {
   border: none;
   padding: 0;
+  background: none;
 }
 
 .education-section .timeframe {
@@ -21,8 +23,8 @@
 
 .education-section h1 > span{
   margin-top: -55px;  /* Size of fixed header */
-  padding-bottom:55px; 
-  display: block; 
+  padding-bottom:55px;
+  display: block;
 }
 
 .education-section .icon {


### PR DESCRIPTION
### Issue
Didn't find an open issue about this.

### Description

I would like to propose this little tweak to improve the look of the education section.
When the background of the section is white, the table still has a gray background around it and it looks very out of place.

### Test Evidence

Before :
![image](https://user-images.githubusercontent.com/29616662/150659099-4bb01c3e-2757-4e99-b3ed-f5ec128d4dd8.png)


After : 
![image](https://user-images.githubusercontent.com/29616662/150659101-ccb32684-f28d-4d3a-a6f5-bccb31537f8f.png)

Thank you 😄 
