### PR TITLE
feat: customMenus in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,7 @@
 {{/*  variables for enabling/disabling parts of the footer  */}}
 {{ $footerEnabled      := site.Params.footer.enable             | default true }}
 {{ $navigationEnabled  := site.Params.footer.navigation.enable  | default true }}
+{{ $customMenusEnabled := site.Params.footer.navigation.customMenus.enable | default true }}
 {{ $contactMeEnabled   := site.Params.footer.contactMe.enable   | default true }}
 {{ $newsletterEnabled  := site.Params.footer.newsletter.enable  | default true }}
 {{ $credentialsEnabled := site.Params.footer.credentials.enable | default true }}
@@ -24,6 +25,11 @@
   {{ $sections:= site.Data.sections }}
   {{ if (index site.Data site.Language.Lang).sections }}
     {{ $sections = (index site.Data site.Language.Lang).sections }}
+  {{ end }}
+
+  {{ $customMenus := site.Params.customMenus }}
+  {{ if (index site.Data site.Language.Lang).site.customMenus }}
+    {{ $customMenus = (index site.Data site.Language.Lang).site.customMenus }}
   {{ end }}
 
   {{ $copyrightNotice := "© 2021 Copyright."}}
@@ -77,6 +83,15 @@
                 </li>
               {{ end }}
             {{- end }}
+            {{ if $customMenusEnabled }}
+              {{ range $customMenus }}
+                {{ if .showOnFooter }}
+                    <li class="nav-item">
+                      <a class="smooth-scroll" href="{{ .url }}">{{ .name }}</a>
+                    </li>
+                {{ end }}
+              {{ end }}
+            {{ end }}
           </ul>
           {{ end }}
         </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{/*  variables for enabling/disabling parts of the footer  */}}
 {{ $footerEnabled      := site.Params.footer.enable             | default true }}
 {{ $navigationEnabled  := site.Params.footer.navigation.enable  | default true }}
-{{ $customMenusEnabled := site.Params.footer.navigation.customMenus.enable | default true }}
+{{ $customMenusEnabled := site.Params.footer.navigation.customMenus | default true }}
 {{ $contactMeEnabled   := site.Params.footer.contactMe.enable   | default true }}
 {{ $newsletterEnabled  := site.Params.footer.newsletter.enable  | default true }}
 {{ $credentialsEnabled := site.Params.footer.credentials.enable | default true }}


### PR DESCRIPTION
Show customMenu links also in footer.
In `config.yaml`,
 - `params.footer.enable` is `true` to show the footer at all
 - `params.footer.navigation.enable` is `true` to show navigation items
   in the footer
 - `params.footer.navigation.customMenus.enable` is `true` to show
   customMenu items

Example:
```
params:
  footer:
    enable: true
    navigation:
      enable: true
      customMenus:
        enable: true
```

In `data/<language>/site.yaml`,
 - `customMenus` must contain at least one entry with `showOnFooter:
   true`

Example:
 ```
 customMenus:
   - name: Imprint
     url: posts/imprint
     showOnFooter: true
 ```

### Issue
<!--- Insert a link to the associated github issue here. -->

### Description

<!-- Insert details about what the changes being proposed are. -->

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->