### PR TITLE
feat: configurable custom navbar items

### DIFF
--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -115,9 +115,11 @@
           </li>
         {{ end }}
         {{ range $customMenus }}
-          <li class="nav-item">
-            <a class="nav-link" href="{{ .url }}">{{ .name }}</a>
-          </li>
+            {{ if .showOnNavbar }}
+              <li class="nav-item">
+                <a class="nav-link" href="{{ .url }}">{{ .name }}</a>
+              </li>
+            {{ end }}
         {{ end }}
         {{ if .IsTranslated }}
           {{ partial "navigators/lang-selector.html" . }}

--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -115,7 +115,7 @@
           </li>
         {{ end }}
         {{ range $customMenus }}
-            {{ if .showOnNavbar }}
+            {{ if (not .hideFromNavbar) }}
               <li class="nav-item">
                 <a class="nav-link" href="{{ .url }}">{{ .name }}</a>
               </li>


### PR DESCRIPTION
The customMenu item from `data/<language>/site.yaml` will only appear if
its property `showOnNavbar` is `true`.

Example:
```
customMenus:
  - name: Imprint
    url: posts/imprint
    showOnNavbar: false
```

### Issue
<!--- Insert a link to the associated github issue here. -->

### Description

<!-- Insert details about what the changes being proposed are. -->

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->