### PR TITLE
add calculation to line up lines

### DIFF
--- a/static/css/sections/experiences.css
+++ b/static/css/sections/experiences.css
@@ -81,7 +81,7 @@
 }
 
 .top-right {
-  left: 50%;
+  left: calc(50% - 3px);
   top: -50%;
 }
 


### PR DESCRIPTION
### Issue
Hopefully fixes hugo-toha/toha#515

### Description

Since the element `.vertical-line-left-adjustment::after ` had a calculated value of 50% - 3px I added that to the corner object as well.

### Test Evidence

![image](https://user-images.githubusercontent.com/1520296/151686297-aa6c0b8f-ddc5-4584-9100-e230d7e006c0.png)
