### PR TITLE
fix: translated "Search" in search box

### DIFF
--- a/i18n/bn.toml
+++ b/i18n/bn.toml
@@ -118,3 +118,6 @@ other = "নোট সমূহ"
 
 [disclaimer_text]
 other = "দায় বিজ্ঞপ্তি"
+
+[search]
+other = "Search"

--- a/i18n/bn.toml
+++ b/i18n/bn.toml
@@ -120,4 +120,4 @@ other = "নোট সমূহ"
 other = "দায় বিজ্ঞপ্তি"
 
 [search]
-other = "Search"
+other = "অনুসন্ধান করুন"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -121,3 +121,6 @@ other = "Notizen"
 
 [disclaimer_text]
 other = "Haftungshinweis"
+
+[search]
+other = "Suche"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -121,3 +121,6 @@ other = "Notes"
 
 [disclaimer_text]
 other = "Liability Notice"
+
+[search]
+other = "Search"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -123,4 +123,4 @@ other = "Notas"
 other = "Aviso de responsabilidad"
 
 [search]
-other = "Search"
+other = "Búsqueda"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -121,3 +121,6 @@ other = "Notas"
 
 [disclaimer_text]
 other = "Aviso de responsabilidad"
+
+[search]
+other = "Search"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -121,3 +121,6 @@ other = "Remarques"
 
 [disclaimer_text]
 other = "Avis de responsabilité"
+
+[search]
+other = "Search"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -123,4 +123,4 @@ other = "Remarques"
 other = "Avis de responsabilité"
 
 [search]
-other = "Search"
+other = "Chercher"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -121,3 +121,6 @@ other = "टिप्पणियाँ"
 
 [disclaimer_text]
 other = "दायित्व सूचना"
+
+[search]
+other = "Search"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -123,4 +123,4 @@ other = "टिप्पणियाँ"
 other = "दायित्व सूचना"
 
 [search]
-other = "Search"
+other = "खोज"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -121,3 +121,6 @@ other = "Catatan"
 
 [disclaimer_text]
 other = "Pemberitahuan Kewajiban"
+
+[search]
+other = "Search"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -123,4 +123,4 @@ other = "Catatan"
 other = "Pemberitahuan Kewajiban"
 
 [search]
-other = "Search"
+other = "Mencari"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -123,4 +123,4 @@ other = "Appunti"
 other = "Avviso di responsabilità"
 
 [search]
-other = "Search"
+other = "Ricerca"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -121,3 +121,6 @@ other = "Appunti"
 
 [disclaimer_text]
 other = "Avviso di responsabilità"
+
+[search]
+other = "Search"

--- a/i18n/jp.toml
+++ b/i18n/jp.toml
@@ -120,4 +120,4 @@ other = "ノート"
 other = "責任通知"
 
 [search]
-other = "Search"
+other = "検索"

--- a/i18n/jp.toml
+++ b/i18n/jp.toml
@@ -118,3 +118,6 @@ other = "ノート"
 
 [disclaimer_text]
 other = "責任通知"
+
+[search]
+other = "Search"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -121,3 +121,6 @@ other = "메모"
 
 [disclaimer_text]
 other = "책임 고지"
+
+[search]
+other = "Search"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -123,4 +123,4 @@ other = "메모"
 other = "책임 고지"
 
 [search]
-other = "Search"
+other = "찾다"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -120,3 +120,5 @@ other = "Opmerkingen"
 
 [disclaimer_text]
 other = "Haftungshinweis"
+[search]
+other = "Search"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -121,4 +121,4 @@ other = "Opmerkingen"
 [disclaimer_text]
 other = "Haftungshinweis"
 [search]
-other = "Search"
+other = "Zoekopdracht"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -121,3 +121,6 @@ other = "Ноты"
 
 [disclaimer_text]
 other = "Уведомление об ответственности"
+
+[search]
+other = "Search"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -123,4 +123,4 @@ other = "Ноты"
 other = "Уведомление об ответственности"
 
 [search]
-other = "Search"
+other = "Поиск"

--- a/i18n/vn.toml
+++ b/i18n/vn.toml
@@ -121,3 +121,6 @@ other = "Ghi chú"
 
 [disclaimer_text]
 other = "Thông báo trách nhiệm"
+
+[search]
+other = "Search"

--- a/i18n/vn.toml
+++ b/i18n/vn.toml
@@ -123,4 +123,4 @@ other = "Ghi chú"
 other = "Thông báo trách nhiệm"
 
 [search]
-other = "Search"
+other = "Tìm kiếm"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -121,3 +121,6 @@ other = "笔记"
 
 [disclaimer_text]
 other = "免责声明"
+
+[search]
+other = "Search"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -123,4 +123,4 @@ other = "笔记"
 other = "免责声明"
 
 [search]
-other = "Search"
+other = "搜索"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -123,4 +123,4 @@ other = "筆記"
 other = "免責聲明"
 
 [search]
-other = "Search"
+other = "搜索"

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -121,3 +121,6 @@ other = "筆記"
 
 [disclaimer_text]
 other = "免責聲明"
+
+[search]
+other = "Search"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -20,7 +20,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,7 +20,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -20,7 +20,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/notes/list.html
+++ b/layouts/notes/list.html
@@ -21,7 +21,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/notes/single.html
+++ b/layouts/notes/single.html
@@ -21,7 +21,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -20,7 +20,7 @@
     <div class="sidebar-holder">
       <div class="sidebar" id="sidebar">
         <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
-          <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box" />
+          <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">


### PR DESCRIPTION
Implemented i18n for term "Search" in search box. Added translation
(mostly "Search") in i18n/*.toml files.

### Issue
<!--- Insert a link to the associated github issue here. -->

### Description

<!-- Insert details about what the changes being proposed are. -->

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->