### PR TITLE
Don't show `Responsibilities` header, if there aren't any

### DIFF
--- a/layouts/partials/sections/experiences/single-position.html
+++ b/layouts/partials/sections/experiences/single-position.html
@@ -12,10 +12,12 @@
     <!-- Add company overview -->
     <p>{{ .company.overview | markdownify }}</p>
     <!-- Add the responsibilities handled at this position -->
+    {{ if $position.responsibilities }}
     <h6 class="text-muted">{{ i18n "responsibilities" }}</h6>
     <ul class="justify-content-around">
     {{ range $position.responsibilities }}
         <li>{{ . | markdownify }}</li>
     {{ end }}
     </ul>
+    {{ end }}
 </div>


### PR DESCRIPTION
### Issue

Fixes https://github.com/hugo-toha/toha/issues/539

### Description

<!-- Insert details about what the changes being proposed are. -->
Block `{{ if $position.responsibilities }}` is responsible for rendering `Responsibilities:` only when there is at least single responsbility

### Test Evidence
Run locally
<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->
![after-with-the-fix](https://user-images.githubusercontent.com/5395690/155900128-912f21e8-feec-41f9-9eb9-6a05a164654e.png)

