### PR TITLE
Refine rss build logic

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,10 +1,12 @@
 {{- $pctx := . -}}
 {{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
 {{- $pages := slice -}}
-{{- if or $.IsHome $.IsSection -}}
+{{- if $.IsHome -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- else if $.IsSection -}}
 {{- $pages = $pctx.RegularPagesRecursive -}}
 {{- else -}}
-{{- $pages = $pctx.Pages -}}
+{{- $pages = $pctx.RegularPagesRecursive -}}
 {{- end -}}
 {{- $limit := .Site.Config.Services.RSS.Limit -}}
 {{- if ge $limit 1 -}}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -28,7 +28,7 @@
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}
     {{ range $pages }}
-    {{- if ne .URL "search" -}}
+    {{- if ne .RelPermalink "/search/" -}}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
### Issue
When isHome was true the Recursive pages method didn't work.

### Description

@salastro @hossainemruz I am not sure why my site has the isHome variable set as false, but the section as true always, but this was the best solution I could find out there.

Because I am not confident in this please double check that the logic makes sense