### PR TITLE
Post specific togglable TOC

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -179,7 +179,7 @@
 
 {{ define "toc" }}
   <section class="toc-section" id="toc-section">
-    {{ if site.Params.enableTOC }}
+    {{ if and site.Params.enableTOC ( .Params.enableTOC | default true ) }}
     <div class="toc-holder">
       <h5 class="text-center pl-3">{{ i18n "toc_heading" }}</h5>
       <hr>


### PR DESCRIPTION
### Issue

Fixes #574 

### Description

If both site-configured TOC and post-configured TOC is set to true, then enable TOC, disable otherwise. The default of post-configured TOC is `true`.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->