### PR TITLE
Added logic to the education icon line

### DIFF
--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -12,13 +12,16 @@
         <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
 
-    <div class="container">
-        <table class="education-info-table">
-            <tbody>
-                {{ range .degrees}}
-                <tr>
-                    <td class="icon">
-                        <div class="hline"></div>
+  <div class="container">
+    <table class="education-info-table">
+        <tbody>
+            {{ $count := len .degrees }}
+            {{ range .degrees}}
+            <tr>
+                <td class="icon">
+                    {{ if gt $count 1}}
+                    <div class="hline"></div>
+                    {{ end }}
                         <div class="icon-holder">
                             <i class="fas {{ .icon }}"></i>
                         </div>

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -12,13 +12,16 @@
         <span id="{{ $sectionID }}"></span>{{ .section.name }}</h1>
   {{ end }}
 
-    <div class="container">
-        <table class="education-info-table">
-            <tbody>
-                {{ range .degrees}}
-                <tr>
-                    <td class="icon">
-                        <div class="hline"></div>
+  <div class="container">
+    <table class="education-info-table">
+        <tbody>
+            {{ $count := len .degrees }}
+            {{ range .degrees}}
+            <tr>
+                <td class="icon">
+                    {{ if gt $count 1}}
+                    <div class="hline"></div>
+                    {{ end }}
                         <div class="icon-holder">
                             <i class="fas {{ .icon }}"></i>
                         </div>


### PR DESCRIPTION
### Issue
No issue created

### Description

Hello,

This is a little tweak that allows someone to only have one degree without having the line in the logo pointing to an empty space. 

So, if someone has only one degree the line won't appear, but if they have more, the line will be appear.

### Test Evidence

Before:
![image](https://user-images.githubusercontent.com/29616662/167309490-85a3340d-a662-4192-9247-a8a24881f594.png)


After: 
![image](https://user-images.githubusercontent.com/29616662/167309418-9624d407-9081-48e0-921e-bdbb150a6679.png)

With multiple degrees:
![image](https://user-images.githubusercontent.com/29616662/167309449-38594578-3fa5-46d1-950a-723647535f6f.png)

Thank you 😃 

