### PR TITLE
Added matomo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A [Hugo](https://gohugo.io/) theme for a personal portfolio with minimalist desi
   - GoatCounter
   - counter.dev
   - Google Analytics
+  - Matomo/Piwik
 - Comment Support
   - [Disqus](https://disqus.com/)
   - [Valine](https://valine.js.org/)

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -40,6 +40,24 @@
             src="//gc.zgo.at/count.js"
             ></script>
         {{ end }}
+
+        <!-- Piwik/Matomo -->
+        {{ with .matomo }}
+        <!-- Matomo -->
+            <script>
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="//{{ .instance }}/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '{{ .siteId }}']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+            </script>
+        {{ end }}
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
### Issue
No issue was created

### Description

Added basic support for Matomo (or Piwik) analytics.

Example config:
```yaml
params:
  features:
    analytics:
      enabled: true
      matomo:
        instance: matomo.ddavo.me
        siteId: 1
```

### Test Evidence

- Add the instance name and page id to the configuration
- Visit the web and check in the JS log that the script has loaded successfully without erros
- Check in Matomo control panel (or with the API) that there has been a new visit to the site