### PR TITLE
Improved german localization

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -72,10 +72,10 @@ other = "Belegte Kurse"
 other = "Kursname"
 
 [total_credit]
-other = "Gesamtguthaben"
+other = "Mögliche Punktzahl"
 
 [obtained_credit]
-other = "Erhaltenes Guthaben"
+other = "Note"
 
 [extracurricular_activities]
 other = "Außerschulische Aktivitäten"
@@ -108,7 +108,7 @@ other = "Star"
 other = "Details"
 
 [err_404]
-other = "Die Seite nach der Seite ist noch nicht vorhanden."
+other = "Die von Ihnen gesuchte Seite ist noch nicht vorhanden."
 
 [more]
 other = "Mehr"


### PR DESCRIPTION
"Guthaben" is used for banking loans.
Changed to "Punktzahl" and "Note" to
better reflect the german education
system.

The 404 error message was just
nonsense. Changed it to correct
translation of english version.