### PR TITLE
Only load flag CSS if showing flag icons

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,8 +7,9 @@
 <link rel="stylesheet" href="{{ "/css/layouts/main.css" | relURL }}"/>
 <link rel="stylesheet" href="{{ "/css/navigators/navbar.css" | relURL }}"/>
 <link rel="stylesheet" href="{{ "/css/plyr.css" | relURL }}"/>
+{{ if ne site.Params.showFlags false }}
 <link rel="stylesheet" href="{{ "/css/flag-icon.min.css" | relURL }}"/>
-
+{{ end }}
 <!--=================== fonts ==============================-->
 <link rel="stylesheet" href="{{ "/google-fonts/Mulish/mulish.css" | relURL }}"/>
 


### PR DESCRIPTION
### Issue
Currently, if you had `showFlags: false` the CSS file  `/css/flag-icon.min.css` is still loaded even though I am pretty sure it is not being used.

### Description

This PR disables the loading of the flag CSS file if `showFlags` is false.

### Test Evidence

Tested locally by setting `showFlags:` to false and not seeing the flag CSS then and then set to true and see it be loaded.