### PR TITLE
Centered Tags on Posts page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -56,12 +56,10 @@
         </div>
         {{ if site.Params.enableTags }}
         <div class="taxonomy-terms">
-            <ul>
             {{ range .Params.tags }}
             {{ $url:= printf "tags/%s" . }}
             <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
             {{ end }}
-          </ul>
         </div>
         {{ end }}
         <div class="post-content" id="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -56,10 +56,12 @@
         </div>
         {{ if site.Params.enableTags }}
         <div class="taxonomy-terms">
+          <ul style="padding-left: 0;">
             {{ range .Params.tags }}
             {{ $url:= printf "tags/%s" . }}
             <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
             {{ end }}
+          </ul>
         </div>
         {{ end }}
         <div class="post-content" id="post-content">


### PR DESCRIPTION
### Description

Fix center issue on post tags

### Test Evidence
Before:
![image](https://user-images.githubusercontent.com/39769010/198868356-ccbad744-04af-4663-bbd3-ef1897f8781b.png)
After:
![image](https://user-images.githubusercontent.com/39769010/198854515-ba130efa-766d-48c4-b4ad-15db49fd7400.png)


