### PR TITLE
Fix recent-posts.html to not display search card

### DIFF
--- a/layouts/partials/sections/recent-posts.html
+++ b/layouts/partials/sections/recent-posts.html
@@ -19,7 +19,7 @@
   {{ end }}
   <div class="container">
     <div class="row" id="recent-post-cards">
-      {{ range first $numShow (where site.RegularPages.ByDate.Reverse "Type" "in" "posts" )}}
+      {{ range first $numShow (where (where site.RegularPages.ByDate.Reverse "Type" "posts" ) "Layout" "!=" "search") }}
         {{ partial "cards/recent-post.html" . }}
       {{ end }}
     </div>


### PR DESCRIPTION
### Issue

Fixes https://github.com/hugo-toha/toha/issues/686 - "Recent Posts" displays "search" card if no or few "posts" have been created

### Description

We see "search" cards displayed in "Recent Posts" when no, or few "posts" exist.

Modelling proposed solution based on "layouts/_default/list.html" which ignores the search layout file.
-   {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->

# layouts/partials/sections/recent-posts.html
## Before change - No posts created
![recent-posts-before-no_posts](https://user-images.githubusercontent.com/116754122/199783256-b36d486a-0a3e-4ba8-8c34-3a210f1edeb2.png)

---

## Before change - One post created
![recent-posts-before-one_post](https://user-images.githubusercontent.com/116754122/199783258-6edb59c8-d959-4443-82fb-462aca1db00c.png)

---

## After change - No posts created
![recent-posts-after-no_posts](https://user-images.githubusercontent.com/116754122/199783249-4014a6a6-f7aa-4788-8803-71d4ab75b4a7.png)

---

## After change - One post created
![recent-posts-after-one_post](https://user-images.githubusercontent.com/116754122/199783674-c910325c-0da7-41b7-8474-14bccf8dabba.png)
