### PR TITLE
Add missing "alt" attributes to img tags in theme-selector.html

### DIFF
--- a/layouts/partials/navigators/theme-selector.html
+++ b/layouts/partials/navigators/theme-selector.html
@@ -4,17 +4,17 @@
   default-theme="{{ site.Params.darkMode.default }}"></div>
 <a class="nav-link dropdown-toggle"  href="#" id="themeSelector" role="button"
   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-  <img id="navbar-theme-icon-svg" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20>
+  <img id="navbar-theme-icon-svg" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20 alt="Dark Theme">
 </a>
 <div class="dropdown-menu dropdown-menu-icons-only" aria-labelledby="themeSelector">
   <a class="dropdown-item nav-link" href="#" onclick="enableLightTheme()">
-    <img class="menu-icon-center" src="{{ "/icons/sun-svgrepo-com.svg" }}" width=20>
+    <img class="menu-icon-center" src="{{ "/icons/sun-svgrepo-com.svg" }}" width=20 alt="Light Theme">
   </a>
   <a class="dropdown-item nav-link" href="#" onclick="enableDarkTheme()">
-    <img class="menu-icon-center" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20>
+    <img class="menu-icon-center" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20 alt="Dark Theme">
   </a>
   <a class="dropdown-item nav-link" href="#" onclick="useSystemTheme()">
-    <img class="menu-icon-center" src="{{ "/icons/computer-svgrepo-com.svg" }}" width=20>
+    <img class="menu-icon-center" src="{{ "/icons/computer-svgrepo-com.svg" }}" width=20 alt="System Theme">
   </a>
 </div>
 </li>


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
#688 - HTML Proofer complains that "alt" attributes are missing from img tags in theme-selector.html

### Description

<!-- Insert details about what the changes being proposed are. -->
HTML Proofer complains that "alt" attributes are missing from img tags generated by layouts/partials/navigators/theme-selector.html

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->

## Before patch:
![theme-selector-before](https://user-images.githubusercontent.com/116754122/200118686-8bd3a93f-d380-41a1-a7dd-bc641865e15f.png)

## After patch:
![theme-selector-after](https://user-images.githubusercontent.com/116754122/200118685-02371630-9ab6-4d98-bffc-e6aa2551b67d.png)
