### PR TITLE
Fix links of `posts`, `notes`, and `tags/%s` directories

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -24,7 +24,7 @@
         </form>
         <div class="sidebar-tree">
           <ul class="tree" id="tree">
-            <li id="list-heading"><a href="{{ "/posts" | relLangURL }}" data-filter="all">{{ i18n "posts" }}</a></li>
+            <li id="list-heading"><a href="{{ "/posts/" | relLangURL }}" data-filter="all">{{ i18n "posts" }}</a></li>
             <div class="subtree">
                 {{ partial "navigators/sidebar.html" (dict "menuName" "sidebar" "menuItems" site.Menus.sidebar "ctx" .) }}
             </div>
@@ -58,7 +58,7 @@
         <div class="taxonomy-terms">
           <ul style="padding-left: 0;">
             {{ range .Params.tags }}
-            {{ $url:= printf "tags/%s" . }}
+            {{ $url:= printf "tags/%s/" . }}
             <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
             {{ end }}
           </ul>

--- a/layouts/partials/navigators/navbar.html
+++ b/layouts/partials/navigators/navbar.html
@@ -106,12 +106,12 @@
         {{ end }}
         {{ if $blogEnabled }}
           <li class="nav-item">
-            <a class="nav-link" id="blog-link" href="{{ "/posts" | relLangURL }}">{{ i18n "posts" }}</a>
+            <a class="nav-link" id="blog-link" href="{{ "/posts/" | relLangURL }}">{{ i18n "posts" }}</a>
           </li>
         {{ end }}
         {{ if $notesEnabled }}
           <li class="nav-item">
-            <a class="nav-link" id="note-link" href="{{ "/notes" | relLangURL }}">{{ i18n "notes" }}</a>
+            <a class="nav-link" id="note-link" href="{{ "/notes/" | relLangURL }}">{{ i18n "notes" }}</a>
           </li>
         {{ end }}
         {{ range $customMenus }}


### PR DESCRIPTION
### Issue
https://toha-guides.netlify.app/posts is going to be redirected to https://toha-guides.netlify.app/posts/ because `posts` is a directory. `notes` and `tags/%s` are also the same.  
There are such redirect links on some pages. For performance, it's not preferred to redirect them.

### Description
This PR correct `posts`, `notes` and `tags/%s` to `posts/`, `notes/` and `tags/%s/`

### Test Evidence
Their links are going to be redirected to the correct pages, so there is no change in their behavior.
For example, the `Posts` link at the navbar in https://toha-guides.netlify.app/ will change from https://toha-guides.netlify.app/posts into https://toha-guides.netlify.app/posts/, but Both destination pages will be the same.

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->