### PR TITLE
Brazilian Portuguese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For more details about the features please visit [here](https://toha-guides.netl
 - Arabic (العربية)
 - Português
 - Català
+- Português Brasileiro
 
 To know more about how to translate your site, please visit [here](https://toha-guides.netlify.app/posts/translation/). Follow, the data and post format from this [example site](https://hugo-toha.github.io).
 

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -1,0 +1,126 @@
+# More documentation here: https://github.com/nicksnyder/go-i18n
+[home]
+other = "Início"
+
+[posts]
+other = "Postagens"
+
+[toc_heading]
+other = "Tabela de conteúdos"
+
+[tags]
+other = "Etiquetas"
+
+[categories]
+other = "Categorias"
+
+[at]
+other = "em"
+
+[resume]
+other = "Currículo"
+
+[navigation]
+other = "Navegação"
+
+[contact_me]
+other = "Contato:"
+
+[email]
+other = "E-mail"
+
+[phone]
+other = "Telefone"
+
+[newsletter_text]
+other = "Se mantenha atualizado com notificações por e-mail"
+
+[newsletter_input_placeholder]
+other = "Inserir email"
+
+[newsletter_warning]
+other = "Ao assinar nossa newsletter, você está concordando em receber a newsletter deste site."
+
+[submit]
+other = "Enviar"
+
+[hugoAttributionText]
+other = "Desenvolvido por"
+
+[prev]
+other = "Anterior"
+
+[next]
+other = "Próximo"
+
+[share_on]
+other = "Compartilhe"
+
+[improve_this_page]
+other = "Melhore esta página"
+
+[out_of]
+other = "de"
+
+[publications]
+other = "Publicações"
+
+[taken_courses]
+other = "Cursos realizados"
+
+[course_name]
+other = "Nome do Curso"
+
+[total_credit]
+other = "Créditos Totais"
+
+[obtained_credit]
+other = "Créditos Obtidos"
+
+[extracurricular_activities]
+other = "Atividades Extracurriculares"
+
+[show_more]
+other = "Ver Mais"
+
+[show_less]
+other = "Ver Menos"
+
+[responsibilities]
+other = "Responsabilidades:"
+
+[present]
+other = "Presente"
+
+[comments_javascript]
+other = "Por favor ative JavaScript para ver o"
+
+[comments_by]
+other = "comentários por"
+
+[read]
+other = "Ler"
+
+[project_star]
+other = "Star"
+
+[project_details]
+other = "Detalhes"
+
+[err_404]
+other = "A página que você está procurando ainda não está aqui."
+
+[more]
+other = "Mais"
+
+[view_certificate]
+other = "Ver Certificado"
+
+[notes]
+other = "Notas"
+
+[disclaimer_text]
+other = "Nota legal"
+
+[search]
+other = "Pesquisar"


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Fixes https://github.com/hugo-toha/toha/issues/726

### Description
<!-- Insert details about what the changes being proposed are. -->
I'm adding Brazilian Portuguese translation to Toha.
### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->
<img width="872" alt="toha" src="https://user-images.githubusercontent.com/42983358/210908649-969d51e7-4403-43c1-a29b-ab6a21337cc1.png">
<img width="851" alt="homemissingtoha" src="https://user-images.githubusercontent.com/42983358/210909665-f1526b39-b6db-4d32-92be-f73b5be39f2e.png">

Notice that the "Home" button is missing, because there's no proper pt-br translation files. Also, the theme is having some trouble accepting only "pt-br" files as a language. The reason there's a lot of missing things from the Menu there is because I removed them when I've taken it, the Menu is working just fine.