### PR TITLE
fix cardHeader

### DIFF
--- a/assets/styles/layouts/main.scss
+++ b/assets/styles/layouts/main.scss
@@ -164,8 +164,9 @@ Yellow:  #FFC212
   
   .card .card-head {
     height: 172px;
-    -o-object-fit: cover;
-    object-fit: cover;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     overflow: hidden;
   }
   


### PR DESCRIPTION
Would it be better to center the preview image vertically?

The left side is after modification, the right side is before modification
![image](https://user-images.githubusercontent.com/32790186/230347449-e7e5ad70-fe24-4d6b-ac98-e5f0ff32638d.png)

The left side is after modification, the right side is before modification
![image](https://user-images.githubusercontent.com/32790186/230347192-2df2689e-1873-452a-850c-aa90f404b964.png)

The left side is after modification, the right side is before modification
![image](https://user-images.githubusercontent.com/32790186/230347072-f1a3de4e-4a3e-4c3f-8aab-f5a35d3ae329.png)
