### PR TITLE
Fixed changing default color scheme in config, affecting the result

### DIFF
--- a/assets/scripts/features/darkmode/darkreader.js
+++ b/assets/scripts/features/darkmode/darkreader.js
@@ -2,7 +2,7 @@ import { enable, disable, auto, setFetchMethod } from 'darkreader'
 import * as params from '@params'
 
 const darkreader = params?.darkmode?.darkreader || {}
-const defaultColorScheme = darkreader.defaultColorScheme || 'system'
+const defaultColorScheme = darkreader.defaultcolorscheme || 'system'
 const theme = {
   brightness: 100,
   contrast: 100,


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
[#754 Changing default color scheme in config.yaml has no effect](https://github.com/hugo-toha/toha/issues/754)

### Description
Upon debugging, I found that, in `/assets/scripts/features/darkmode/darkreader.js` file, `darkreader` object has attribute `defaultcolorscheme` not, `defaultColorScheme`, thus the following code always results in 'system' configuration.

`const defaultColorScheme = darkreader.defaultColorScheme || 'system'`

<!-- Insert details about what the changes being proposed are. -->

### Test Evidence
![image](https://user-images.githubusercontent.com/33568903/233948043-2a040c22-aebe-4695-a93c-daabcdf163c4.png)

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->