### PR TITLE
Fix Issue: Skills logo misaligned #753 

### DIFF
--- a/assets/styles/sections/skills.scss
+++ b/assets/styles/sections/skills.scss
@@ -20,6 +20,7 @@
   
   .card .card-img-xs {
     margin-right: 0.5rem;
+    margin-bottom: 0.75rem;
   }
   
   .card {


### PR DESCRIPTION
### Issue
Fixes #753

### Description
Changed css file to center the logos.

### Test Evidence
Before:
![before](https://github.com/hugo-toha/toha/assets/70479573/08493614-5985-4c64-b219-51d8920b387d)

After:
![after](https://github.com/hugo-toha/toha/assets/70479573/30c4c7d0-d40c-46a7-ad9b-b8ab69ad17d4)