### PR TITLE
Add extracurricular activities url

### DIFF
--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -101,7 +101,11 @@
                                 <h6 class="text-muted">{{ i18n "extracurricular_activities" }}</h6>
                                 <ul>
                                 {{ range .extracurricularActivities }}
-                                    <li>{{ . }}</li>
+                                    {{ if .url }}
+                                        <li><a href="{{ .url }}" title="{{ .name }}" target="_blank" rel="noopener">{{ .name }}</a></li>
+                                    {{ else }}
+                                        <li>{{ .name }}</li>
+                                    {{ end }}
                                 {{ end }}
                                 </ul>
                             </div>

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -101,11 +101,7 @@
                                 <h6 class="text-muted">{{ i18n "extracurricular_activities" }}</h6>
                                 <ul>
                                 {{ range .extracurricularActivities }}
-                                    {{ if .url }}
-                                        <li><a href="{{ .url }}" title="{{ .name }}" target="_blank" rel="noopener">{{ .name }}</a></li>
-                                    {{ else }}
-                                        <li>{{ .name }}</li>
-                                    {{ end }}
+                                    <li>{{ . | markdownify }}</li>
                                 {{ end }}
                                 </ul>
                             </div>

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -101,7 +101,11 @@
                                 <h6 class="text-muted">{{ i18n "extracurricular_activities"}}</h6>
                                 <ul>
                                 {{ range .extracurricularActivities }}
-                                    <li>{{ . }}</li>
+                                    {{ if .url }}
+                                        <li><a href="{{ .url }}" title="{{ .name }}" target="_blank" rel="noopener">{{ .name }}</a></li>
+                                    {{ else }}
+                                        <li>{{ .name }}</li>
+                                    {{ end }}
                                 {{ end }}
                                 </ul>
                             </div>

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -101,11 +101,7 @@
                                 <h6 class="text-muted">{{ i18n "extracurricular_activities"}}</h6>
                                 <ul>
                                 {{ range .extracurricularActivities }}
-                                    {{ if .url }}
-                                        <li><a href="{{ .url }}" title="{{ .name }}" target="_blank" rel="noopener">{{ .name }}</a></li>
-                                    {{ else }}
-                                        <li>{{ .name }}</li>
-                                    {{ end }}
+                                    <li>{{ . | markdownify }}</li>
                                 {{ end }}
                                 </ul>
                             </div>


### PR DESCRIPTION
### Description
Added the possibility to have an url for each extracurricular activity inside education section.

**ATTENTION**: IT WILL BREAK EXTRACURRICULAR ACTIVITIES SECTION

old format:
```yaml
degrees:
- name: Example degree
  icon: fa-graduation-cap
  timeframe: September 2020 - Present
  institution:
    name: Example Institution
    url: "https://www.example.com"

  extracurricularActivities:
  - Example extracurricular activity no url
  - Example extracurricular activity no url
```

new format:
```yaml
degrees:
- name: Example degree
  icon: fa-graduation-cap
  timeframe: September 2020 - Present
  institution:
    name: Example Institution
    url: "https://www.example.com"

  extracurricularActivities:
  - name: Example extracurricular activity with url
    url: "https://www.example.com"
  - name: Example extracurricular activity no url
```

### Test Evidence
using the new format, the result is the following:
![educationSection](https://github.com/hugo-toha/toha/assets/70479573/22cb5eee-c206-4fb9-839c-cf3a3b78b10d)

I haven't added this changes to [hugo-toha/guides](https://github.com/hugo-toha/guides) as there isn't any education post.
However, I've added the changes to [hugo-toha/hugo-toha.github.io #253](https://github.com/hugo-toha/hugo-toha.github.io/pull/253)