### PR TITLE
Add space between expanding icon and category name (Sidebar)

### DIFF
--- a/layouts/partials/navigators/sidebar.html
+++ b/layouts/partials/navigators/sidebar.html
@@ -9,7 +9,7 @@
   {{ if .HasChildren }}
     <!-- Add current entry -->
     <li>
-      <i class="fas {{ $icon }}"></i><a class="{{$class}}" href="{{ .URL }}">{{.Name}}</a>
+      <i class="fas {{ $icon }}"></i><a class="{{$class}}" href="{{ .URL }}"> {{.Name}}</a>
       <!-- Add sub-tree -->
       <ul class="{{ $class }}">
         {{ partial "navigators/sidebar.html" (dict "menuName" $.menuName "menuItems" .Children "ctx" $.ctx) }}


### PR DESCRIPTION
### Issue
There's no space between the expanding icon and the name of a category.

### Description
Add space between symbol and title

### Test Evidence
Before:
![before](https://github.com/hugo-toha/toha/assets/70479573/d3954c5d-628a-4993-ab69-b344a50c9994)

After:
![after](https://github.com/hugo-toha/toha/assets/70479573/cd5472f0-a80e-474d-8522-a35e71369eef)
