### PR TITLE
Add possibility to show tags on post cards

### DIFF
--- a/assets/styles/layouts/list.scss
+++ b/assets/styles/layouts/list.scss
@@ -98,6 +98,22 @@ body.kind-section, body.kind-term {
     width: fit-content;
   }
   
+  .taxonomy-terms-card {
+    text-align: left;
+  }
+  .taxonomy-terms-card li {
+    font-size: 0.5em;
+    list-style-type: none;
+    display: inline-block;
+    background: #248aaa;
+    margin-left: 0.1em;
+    margin-right: 0.1em;
+  }
+  
+  .taxonomy-terms-card a {
+    color: #f9fafc;
+  }
+
   /* ============= Device specific fixes ======= */
   
   /* Large screens such as TV */

--- a/assets/styles/sections/recent-posts.scss
+++ b/assets/styles/sections/recent-posts.scss
@@ -38,6 +38,22 @@
     -webkit-line-clamp: 5; /* number of lines to show */
     -webkit-box-orient: vertical;
   }
+
+  .taxonomy-terms {
+    text-align: left;
+  }
+  .taxonomy-terms li {
+    font-size: 0.5em;
+    list-style-type: none;
+    display: inline-block;
+    background: #248aaa;
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+  }
+  
+  .taxonomy-terms a {
+    color: #f9fafc;
+  }
   
   /* ============= Device specific fixes ======= */
   

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -189,6 +189,7 @@ params:
     # Show tags under the post title
     tags:
       enable: true
+      on_card: true # enables tags in post cards
 
     # Specify whether to show flag in the language selector. Default is true.
     flags:

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -9,6 +9,16 @@
         <p class="card-text post-summary">{{ .Summary }}</p>
       </div>
       <div class="card-footer">
+        {{ if and site.Params.features.tags.enable site.Params.features.tags.on_card }}
+        <div class="taxonomy-terms-card">
+          <ul style="padding-left: 0;">
+            {{ range .Params.tags }}
+            {{ $url:= printf "tags/%s/" . }}
+            <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
         <span class="float-left">{{ .Date.Format "January 2, 2006" }}</span>
         <a
         href="{{ .RelPermalink | relLangURL }}"

--- a/layouts/partials/cards/recent-post.html
+++ b/layouts/partials/cards/recent-post.html
@@ -11,6 +11,16 @@
         <p class="card-text post-summary"> {{ .Summary }}</p>
       </div>
       <div class="card-footer">
+        {{ if and site.Params.features.tags.enable site.Params.features.tags.on_card }}
+        <div class="taxonomy-terms">
+          <ul style="padding-left: 0;">
+            {{ range .Params.tags }}
+            {{ $url:= printf "tags/%s/" . }}
+            <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
         <span class="float-left">{{ .Date.Format "January 2, 2006" }}</span>
         <a href="{{ .RelPermalink }}" title="{{ i18n "read" }}" class="float-right btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
       </div>


### PR DESCRIPTION
### Description
When enabling this feature in `config.yaml`
```yaml
tags:
      enable: true
      on_card: true
```
post cards in `Recent Posts`, `Posts`, `Tags`, etc. will contain the tags that are specified from that post.

### Test Evidence
Before:
![before](https://github.com/hugo-toha/toha/assets/70479573/8447b05c-2728-4475-a720-5e9996c767ad)

After:
![image](https://github.com/hugo-toha/toha/assets/70479573/1c06a017-5b44-41f6-8da9-bf4bb246d297)

### Comments
- I was going to add it to `guides` but they are outdated, tell me if I have to add it to `guides` or to `hugo-toha.github.io` (as disabled, as tags are not enabled in this site).
- If you want, we can change the location of this setting, but I think under `tags:` in `config.yaml`  is the best location.
- Also, we can change the name of this setting.