### PR TITLE
Add reading time, #679

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -264,6 +264,9 @@ params:
         plyr:
           # options doc: https://github.com/sampotts/plyr#options
           # fullscreen: true
+    
+    readingTime:
+      enable: true
 
 
   # Provide footer configuration.

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -265,6 +265,7 @@ params:
           # options doc: https://github.com/sampotts/plyr#options
           # fullscreen: true
     
+    # Enable reading time support in post cards and in post pages
     readingTime:
       enable: true
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p>{{ .Page.Date | time.Format ":date_full" }}</p>
+          <p>{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</p>
         </div>
 
         <div class="title">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p>{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</p>
+          <p>{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</p>
         </div>
 
         <div class="title">

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -19,7 +19,7 @@
           </ul>
         </div>
         {{ end }}
-        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</span>
+        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</span>
         <a
         href="{{ .RelPermalink | relLangURL }}"
         class="float-right btn btn-outline-info btn-sm"

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -19,7 +19,7 @@
           </ul>
         </div>
         {{ end }}
-        <span class="float-left">{{ .Date.Format "January 2, 2006" }}</span>
+        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</span>
         <a
         href="{{ .RelPermalink | relLangURL }}"
         class="float-right btn btn-outline-info btn-sm"

--- a/layouts/partials/cards/recent-post.html
+++ b/layouts/partials/cards/recent-post.html
@@ -21,7 +21,7 @@
           </ul>
         </div>
         {{ end }}
-        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</span>
+        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</span>
         <a href="{{ .RelPermalink }}" title="{{ i18n "read" }}" class="float-right btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
       </div>
     </div>

--- a/layouts/partials/cards/recent-post.html
+++ b/layouts/partials/cards/recent-post.html
@@ -21,7 +21,7 @@
           </ul>
         </div>
         {{ end }}
-        <span class="float-left">{{ .Date.Format "January 2, 2006" }}</span>
+        <span class="float-left">{{ .Date.Format "January 2, 2006" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{end}}</span>
         <a href="{{ .RelPermalink }}" title="{{ i18n "read" }}" class="float-right btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
       </div>
     </div>


### PR DESCRIPTION
### Issue
Fixes #679

### Description
Add reading time support into post cards and post pages. To enable this feature, add into `config.yaml/`params/features the following:

```yaml
    # Enable reading time support in post cards and in post pages
    readingTime:
      enable: true
```

### Test Evidence
Post pages:
![image](https://github.com/hugo-toha/toha/assets/70479573/3077e85a-b7b5-4255-9a72-4f5ae84fabd4)

Post cards:
![image](https://github.com/hugo-toha/toha/assets/70479573/22b8411f-e405-4503-8e54-50f3078f4f72)
