### PR TITLE
fix dark mode: absolute to relative icon path

### DIFF
--- a/layouts/partials/navigators/theme-selector.html
+++ b/layouts/partials/navigators/theme-selector.html
@@ -1,17 +1,17 @@
 <li class="nav-item dropdown">
 <a class="nav-link dropdown-toggle"  href="#" id="themeSelector" role="button"
   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-  <img id="navbar-theme-icon-svg" class="theme-icon" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20 alt="Dark Theme">
+  <img id="navbar-theme-icon-svg" class="theme-icon" src="{{ "icons/moon-svgrepo-com.svg" | relURL }}" width=20 alt="Dark Theme">
 </a>
 <div id="themeMenu" class="dropdown-menu dropdown-menu-icons-only" aria-labelledby="themeSelector">
   <a class="dropdown-item nav-link" href="#" data-scheme="light">
-    <img class="theme-icon" src="{{ "/icons/sun-svgrepo-com.svg" }}" width=20 alt="Light Theme">
+    <img class="theme-icon" src="{{ "icons/sun-svgrepo-com.svg" | relURL }}" width=20 alt="Light Theme">
   </a>
   <a class="dropdown-item nav-link" href="#" data-scheme="dark">
-    <img class="theme-icon" src="{{ "/icons/moon-svgrepo-com.svg" }}" width=20 alt="Dark Theme">
+    <img class="theme-icon" src="{{ "icons/moon-svgrepo-com.svg" | relURL }}" width=20 alt="Dark Theme">
   </a>
   <a class="dropdown-item nav-link" href="#" data-scheme="system">
-    <img class="theme-icon" src="{{ "/icons/computer-svgrepo-com.svg" }}" width=20 alt="System Theme">
+    <img class="theme-icon" src="{{ "icons/computer-svgrepo-com.svg" | relURL }}" width=20 alt="System Theme">
   </a>
 </div>
 </li>


### PR DESCRIPTION
### Issue
when use a base url with a folder dark mode icon get 404

### Test Evidence
![Capture d’écran du 2023-08-25 16-27-08](https://github.com/hugo-toha/toha/assets/29679418/4ad57969-9123-479d-b3fb-e0067f76480d)
![Capture d’écran du 2023-08-25 16-26-37](https://github.com/hugo-toha/toha/assets/29679418/1c316672-6339-4194-b70e-0de8ef99b359)
