### PR TITLE
Fix featured post section after update

### DIFF
--- a/layouts/partials/sections/featured-posts.html
+++ b/layouts/partials/sections/featured-posts.html
@@ -15,7 +15,7 @@
     <div class="row" id="recent-post-cards">
       {{ range $post := .posts}}
         {{ with site.GetPage $post }}
-          {{ partial "cards/recent-post.html" . }}
+          {{ partial "cards/post.html" . }}
         {{ end }}
       {{ end }}
     </div>


### PR DESCRIPTION
### Issue
After major update of the theme, featured posts section was not rendered.

### Description
Changed from old "recent-post" card to new "post" card.

### Test Evidence
When having this section enabled, now it renders fine.