### PR TITLE
Justify post content (issue #831: Text in post is not justified)

### DIFF
--- a/assets/styles/components/texts.scss
+++ b/assets/styles/components/texts.scss
@@ -82,6 +82,8 @@ html[data-theme='dark'] {
 
   p {
     color: get-dark-color('text-color');
+    text-align: justify;
+    text-justify: inter-word;
   }
 
   input {

--- a/assets/styles/components/texts.scss
+++ b/assets/styles/components/texts.scss
@@ -82,8 +82,6 @@ html[data-theme='dark'] {
 
   p {
     color: get-dark-color('text-color');
-    text-align: justify;
-    text-justify: inter-word;
   }
 
   input {

--- a/assets/styles/components/texts.scss
+++ b/assets/styles/components/texts.scss
@@ -12,6 +12,8 @@ strong {
 
 p {
   color: get-light-color('text-color');
+  text-align: justify;
+  text-justify: inter-word;
 }
 
 input {

--- a/assets/styles/layouts/single.scss
+++ b/assets/styles/layouts/single.scss
@@ -49,6 +49,10 @@ body.kind-page {
                 margin-top: 0px;
               }
 
+              p {
+                text-align: center;
+              }
+
               img {
                 height: 120px;
                 width: 120px;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</p>
+          <p class="text-muted" style="text-align: center;">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</p>
         </div>
 
         <div class="title">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p class="text-muted" style="text-align: center;">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</p>
+          <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}{{ end }}</p>
         </div>
 
         <div class="title">


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Fixes #813.

### Description

<!-- Insert details about what the changes being proposed are. -->
Had to justify `p` element by default cause in some cases the about section also had problems. Had to center the date displayed in posts. There's probably a more neat way to do it.

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->
![image](https://github.com/hugo-toha/toha/assets/70479573/b48d0b19-457c-433a-ac88-44401087b6bd)

You can also visit [bernatbc.tk/posts/](https://bernatbc.tk/posts/) and select any post.
