### PR TITLE
Fix tag separation in post cards

### DIFF
--- a/assets/styles/components/buttons.scss
+++ b/assets/styles/components/buttons.scss
@@ -51,14 +51,16 @@
 
 .tags {
   text-align: left;
-
+  padding-top: 0.5em;
   li {
     font-size: 0.5em;
     list-style-type: none;
     display: inline-block;
     background: get-light-color('accent-color');
-    margin-left: 0.1em;
-    margin-right: 0.1em;
+    margin-left: 0.2em;
+    margin-right: 0.2em;
+    margin-top: 0.6em;
+    margin-bottom: 0.6em;
   }
   a {
     color: get-light-color('text-over-accent-color');


### PR DESCRIPTION
### Issue
Tags are overlapped. (No issue linked).

### Description
Added some padding to the tags to reflect the changes.

### Test Evidence
Before:
![image](https://github.com/hugo-toha/toha/assets/70479573/34dccc11-6b70-4a0c-ab82-59e60ee3392a)
After:
![image](https://github.com/hugo-toha/toha/assets/70479573/95ce14da-4aae-4adb-a4ea-ef05f1e39c68)
