### PR TITLE
Fix distorted post card images (issue #808)

### DIFF
--- a/assets/styles/components/cards.scss
+++ b/assets/styles/components/cards.scss
@@ -22,6 +22,7 @@
   }
 
   .card-img-top {
+    object-fit: cover;
     @include transition();
   }
 
@@ -59,6 +60,7 @@
     &:focus {
       .card-img-top {
         transform: scale(1.2);
+        object-fit: cover;
         @include transition();
       }
     }


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Issue #808 Images in cards are distorted.

### Description
Added `object-fit: cover;` attribute to images

### Test Evidence
![image](https://github.com/hugo-toha/toha/assets/70479573/77f11cea-2030-4c0e-88aa-e25a0705ac5b)
