### PR TITLE
Add minute translation for catalan, spanish and french

### DIFF
--- a/i18n/ad.toml
+++ b/i18n/ad.toml
@@ -124,3 +124,7 @@ other = "Avís de Responsabilitat"
 
 [search]
 other = "Cerca"
+
+[minute]
+one = "minut"
+other = "minuts"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -124,3 +124,7 @@ other = "Aviso de responsabilidad"
 
 [search]
 other = "Búsqueda"
+
+[minute]
+one = "minuto"
+other = "minutos"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -124,3 +124,7 @@ other = "Avis de responsabilité"
 
 [search]
 other = "Chercher"
+
+[minute]
+one = "minute"
+other = "minutes"


### PR DESCRIPTION
### Issue
Recent added feature for translating minute and minutes lead to many languages having incomplete translations.

### Description
Added minute/s translation to:
- catalan (ad)
- spanish (es)
- french (fr)