### PR TITLE
Fix taken courses collapsible

### DIFF
--- a/assets/styles/sections/education.scss
+++ b/assets/styles/sections/education.scss
@@ -120,9 +120,9 @@
                   width: 50%;
                 }
               }
-              ul {
-                margin-bottom: 0;
-              }
+            }
+            ul {
+              margin-bottom: 0;
             }
             .hidden-course {
               display: none;

--- a/assets/styles/sections/education.scss
+++ b/assets/styles/sections/education.scss
@@ -120,13 +120,13 @@
                   width: 50%;
                 }
               }
-              .hidden-course {
-                display: none;
-                @include transition();
-              }
               ul {
                 margin-bottom: 0;
               }
+            }
+            .hidden-course {
+              display: none;
+              @include transition();
             }
           }
         }

--- a/assets/styles/sections/education.scss
+++ b/assets/styles/sections/education.scss
@@ -121,12 +121,12 @@
                 }
               }
             }
-            ul {
-              margin-bottom: 0;
-            }
             .hidden-course {
               display: none;
               @include transition();
+            }
+            ul {
+              margin-bottom: 0;
             }
           }
         }


### PR DESCRIPTION
### Issue
Fixes #839 Taken courses in education section not collapsable when showGrades: true

### Description
Modified `education.scss` to fix the issue by moving out the `hidden-course` component outside the `table` element.

### Test Evidence
![image](https://github.com/hugo-toha/toha/assets/70479573/afe7cbc3-15d7-4087-8658-a8f601188a39)
![image](https://github.com/hugo-toha/toha/assets/70479573/5892b28d-35ed-4ef5-85c4-b82a4bbae4d1)
