### PR TITLE
Fixed and improved circular progess animation on about section

### DIFF
--- a/assets/styles/sections/about.scss
+++ b/assets/styles/sections/about.scss
@@ -20,20 +20,25 @@ $progress-bar-colors: (
 }
 
 @mixin circular-progress-animation-breakpoints() {
-  $progress: 50;
+  $progress: 0;
   $duration: 0;
+  $delay: 1.8;
 
-  @for $i from 1 through 10 {
+  @for $i from 0 through 20 {
     .circular-progress-percentage-#{$progress} {
       animation: circular-loading-#{$progress} #{$duration}s linear forwards 1.8s;
     }
+    .circular-progress-percentage-#{$progress}-delay {
+        animation-delay: #{$delay}s;
+    }
     $progress: $progress + 5;
     $duration: $duration + 0.18;
+    $delay: $duration + 1.8;
   }
 }
 
 @mixin circular-progress-animation-keyframes($progress, $degree, $keyframes) {
-  @for $i from 1 through $keyframes {
+  @for $i from 0 through $keyframes {
     @keyframes circular-loading-#{$progress} {
       0% {
         transform: rotate(0);
@@ -122,7 +127,6 @@ $progress-bar-colors: (
         border-bottom-left-radius: 80px;
         border-right: 0;
         transform-origin: center right;
-        animation: circular-loading-1 1.8s linear forwards;
       }
     }
     .circular-progress-value {
@@ -144,8 +148,7 @@ $progress-bar-colors: (
     }
     @include circular-progress-bar-color();
     @include circular-progress-animation-breakpoints();
-    @include circular-progress-animation-keyframes($progress: 50, $degree: 0, $keyframes: 10);
-    @include circular-progress-animation-keyframes($progress: 1, $degree: 180, $keyframes: 5);
+    @include circular-progress-animation-keyframes($progress: 0, $degree: 0, $keyframes: 20);
   }
 
   @include media('<=large') {

--- a/layouts/partials/misc/badge.html
+++ b/layouts/partials/misc/badge.html
@@ -12,10 +12,16 @@
     {{ if hasPrefix .color "#"}}
         {{ $predefinedColor = false }}
     {{ end }}
+    {{ $leftProgress := 0 }}
+    {{ $rightProgress := .percentage }}
+    {{ if ge .percentage 50 }}
+        {{ $rightProgress = 50 }}
+        {{ $leftProgress = sub .percentage 50 }}
+    {{ end }}
     <div class="circular-progress {{if $predefinedColor}}{{ .color }}{{end}}">
     <span class="circular-progress-left">
         <span
-        class="circular-progress-bar circular-progress-percentage-{{ .percentage }}"
+        class="circular-progress-bar circular-progress-percentage-{{ $leftProgress }}  circular-progress-percentage-50-delay"
         {{ if not $predefinedColor }}
             style="border-color: {{.color}};"
         {{ end }}
@@ -23,7 +29,7 @@
     </span>
     <span class="circular-progress-right">
         <span
-        class="circular-progress-bar"
+        class="circular-progress-bar circular-progress-percentage-{{ $rightProgress }}"
         {{ if not $predefinedColor }}
             style="border-color: {{.color}};"
         {{ end }}


### PR DESCRIPTION
### Description
These changes was about to fix some behaviors about the circular progress animations.
Currently the circular progress only supports values greater then 50% and it breaks if you put 100%.
Please look at the "Problem Solving" and "Comunication" soft skills in following screenshots that should be 100 and 40 but renders as 50.

<img width="269" alt="Screenshot 2023-12-19 alle 11 01 01" src="https://github.com/hugo-toha/toha/assets/25266591/9bdd9ba8-dc42-4913-ad83-ce9be7f9d36f">
<img width="543" alt="Screenshot 2023-12-19 alle 11 01 13" src="https://github.com/hugo-toha/toha/assets/25266591/044dd020-0c7e-4d76-9bfc-0e7117db7bb1">

### Test Evidence
After the fix, now it is possible to use all values between 0 - 100 with steps (or granularity) of 5.
Look at the screenshot that render the same data of previous one.

<img width="567" alt="Screenshot 2023-12-19 alle 11 01 50" src="https://github.com/hugo-toha/toha/assets/25266591/4ea457c0-b0f1-4ed8-88a3-1ae8c1d62445">
