### PR TITLE
Specify European Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For more details about the features please visit [here](https://toha-guides.netl
 - Tiếng Việt
 - Turkish
 - Arabic (العربية)
-- Português
+- Português Europeu
 - Català
 - Português Brasileiro
 

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -124,3 +124,7 @@ other = "Nota legal"
 
 [search]
 other = "Pesquisar"
+
+[minute]
+one = "minuto"
+other = "minutos"

--- a/i18n/pt-pt.toml
+++ b/i18n/pt-pt.toml
@@ -124,3 +124,7 @@ other = "Nota legal"
 
 [search]
 other = "Pesquisar"
+
+[minute]
+one = "minuto"
+other = "minutos"


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
I did not report an issue, but with the brasilian portuguese available it seems that sites with the pt language now use pt-br, instead of pt

### Description

<!-- Insert details about what the changes being proposed are. -->

Updated some translations and renamed the file from pt to pt-pt

### Test Evidence
<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->