### PR TITLE
Add Researchgate as contact option

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -115,6 +115,10 @@
                 <li><a href={{ printf "https://github.com/%s" $value }} target="_blank" rel="noopener">
                   <span><i class="fab fa-github"></i></span> <span>{{ $value }}</span>
                 </a></li>
+              {{ else if (eq $key "researchgate") }}
+                <li><a href={{ printf "https://www.researchgate.net/profile/%s" $value }} target="_blank" rel="noopener">
+                  <span><i class="fab fa-researchgate"></i></span> <span>{{ $author.name }}</span>
+                </a></li>            
               {{ else if reflect.IsMap $value }}
                 <li>
                   {{ if (and (isset $value "url") (isset $value "icon"))}}


### PR DESCRIPTION
### Issue
[Researchgate ](https://www.researchgate.net/) is a platform where scientists and researchers connect and share research.

### Description

This PR adds support for the `researchgate` key  in the `contactInfo` section of `author.yaml`

### Test Evidence

```yaml
contactInfo:
  researchgate: Dieter-Vansteenwegen
```


![image](https://github.com/hugo-toha/toha/assets/46349482/21f78a8e-dd2c-46e4-84dd-58066a130ca2)


