### PR TITLE
Add select maximum number of posts per page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -32,7 +32,11 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $paginator := .Paginate $posts 12 }}
+      {{ $numShow := 12}}
+      {{ if site.Params.postsPage.maxPostsPerPage}}
+        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
+      {{ end }}
+      {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}
           {{/* ignore the search.md file*/}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -32,10 +32,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow := 12}}
-      {{ if site.Params.postsPage.maxPostsPerPage}}
-        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
-      {{ end }}
+      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -32,7 +32,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
+      {{ $numShow := site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -33,7 +33,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
+      {{ $numShow := site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -33,10 +33,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow := 12}}
-      {{ if site.Params.postsPage.maxPostsPerPage}}
-        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
-      {{ end }}
+      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -33,7 +33,11 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $paginator := .Paginate $posts 12 }}
+      {{ $numShow := 12}}
+      {{ if site.Params.postsPage.maxPostsPerPage}}
+        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
+      {{ end }}
+      {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}
           {{/* ignore the search.md file*/}}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -33,7 +33,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
+      {{ $numShow := site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -33,10 +33,7 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $numShow := 12}}
-      {{ if site.Params.postsPage.maxPostsPerPage}}
-        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
-      {{ end }}
+      {{ $numShow = site.Params.features.pagination.maxPostsPerPage | default 12}}
       {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -33,7 +33,11 @@
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
       {{ $posts := where .RegularPagesRecursive "Layout" "!=" "search" }}
-      {{ $paginator := .Paginate $posts 12 }}
+      {{ $numShow := 12}}
+      {{ if site.Params.postsPage.maxPostsPerPage}}
+        {{ $numShow = site.Params.postsPage.maxPostsPerPage }}
+      {{ end }}
+      {{ $paginator := .Paginate $posts $numShow }}
       {{ range $paginator.Pages }}
         {{ if .Layout }}
           {{/* ignore the search.md file*/}}


### PR DESCRIPTION
### Issue
None, it's just a feature.

### Description
With this parameter you can select the maximum number of posts that will appear to each page. It will default to 12 (the value that we were using before). To configure it, just add the following lines under the `params` section of `config.yaml`:
```yaml
postsPage:
    maxPostsPerPage: 20 # Default: 12
```

Before I add this into the guides and the example file, tell me if you want to change the name of the parameter, or if I have to change the location of it.

### Test Evidence

#### maxPostsPerPage=5
![image](https://github.com/hugo-toha/toha/assets/70479573/da13130f-179c-4492-ba42-aeeac5bd0713)
#### maxPostsPerPage=10
![image](https://github.com/hugo-toha/toha/assets/70479573/ee1d1ef0-3f5d-4733-b953-969fe9fcf7e9)
