### PR TITLE
Add param profile to hide author in post

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -50,7 +50,7 @@
           <h1>{{ .Page.Title }}</h1>
         </div>
 
-        {{ if not .Params.profile | default true }}
+        {{ if not (.Params.profile | default true) }}
         <div class="author-profile ml-auto align-self-lg-center">
           <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,7 +36,7 @@
 
       <!--Content Start-->
       <div class="page-content">
-        {{ if .Params.profile | default true }}
+        {{ if site.Params.features.blog.showAuthor | default true }}
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
@@ -50,7 +50,7 @@
           <h1>{{ .Page.Title }}</h1>
         </div>
 
-        {{ if not (.Params.profile | default true) }}
+        {{ if not (site.Params.features.blog.showAuthor | default true) }}
         <div class="author-profile ml-auto align-self-lg-center">
           <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,15 +36,26 @@
 
       <!--Content Start-->
       <div class="page-content">
+        {{ if .Params.profile | default true }}
         <div class="author-profile ml-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
           <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
-
+        {{ else }}
+        <div style="margin-bottom: 80px;"></div>
+        {{ end }}
+        
         <div class="title">
           <h1>{{ .Page.Title }}</h1>
         </div>
+
+        {{ if not .Params.profile | default true }}
+        <div class="author-profile ml-auto align-self-lg-center">
+          <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} | {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
+        </div>
+        {{ end }}
+
         {{ if site.Params.features.tags.enable }}
           {{partial "misc/tags.html" .Params.tags }}
         {{ end }}


### PR DESCRIPTION
### Issue
Hide author name and image in post? Fixes #867

### Description
Added the possibility to hide author in post by setting the parameter:
```yaml
profile: false #defaults true
```
I know this is not the most elegant solution (I had to add vertical gap).

### Test Evidence
`profile: true` (or no `profile` set):
![image](https://github.com/hugo-toha/toha/assets/70479573/8a8f6fbe-93a1-459a-b0c3-eb6f2918072f)

`profile: false`:
![image](https://github.com/hugo-toha/toha/assets/70479573/dec2ed21-7b41-4fbb-986f-ab1729a733c8)
