### PR TITLE
Changing the translation of 'Notes'

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -117,7 +117,7 @@ other = "Suite"
 other = "Afficher le certificat"
 
 [notes]
-other = "Remarques"
+other = "Notes"
 
 [disclaimer_text]
 other = "Avis de responsabilité"


### PR DESCRIPTION
Changed the translation for the word "Notes" from "Remarques" to "Notes" (as in English).

### Issue

Please check the issue #872.

### Description

Everything is described in the issue #872.


