### PR TITLE
Fix extra anchor in post card tags

### DIFF
--- a/assets/styles/components/buttons.scss
+++ b/assets/styles/components/buttons.scss
@@ -59,12 +59,17 @@
     background: get-light-color('accent-color');
     margin-left: 0.2em;
     margin-right: 0.2em;
-    margin-top: 0.6em;
-    margin-bottom: 0.6em;
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
   }
-  a {
+  button {
+    background-color: transparent;
+    border: none;
     color: get-light-color('text-over-accent-color');
-    text-decoration: none !important;
+    padding-top: 0.1rem;
+    padding-bottom: 0.1rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 }
 
@@ -146,7 +151,7 @@ html[data-theme='dark'] {
   .tags {
     li {
       background: get-dark-color('accent-color');
-      a {
+      button {
         background-color: get-dark-color('bg-card');
         border: 1px solid get-dark-color('muted-text-color');
         color: get-dark-color('text-over-accent-color');

--- a/assets/styles/components/buttons.scss
+++ b/assets/styles/components/buttons.scss
@@ -66,6 +66,7 @@
     background-color: transparent;
     border: none;
     color: get-light-color('text-over-accent-color');
+    text-decoration: none !important;
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;
     padding-left: 0.5rem;

--- a/layouts/partials/misc/tags.html
+++ b/layouts/partials/misc/tags.html
@@ -1,8 +1,8 @@
 <div class="tags">
-    <ul style="padding-left: 0;">
-      {{ range . }}
-      {{ $url:= printf "tags/%s/" . }}
-      <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
-      {{ end }}
-    </ul>
+  <ul style="padding-left: 0;">
+    {{ range . }}
+    {{ $url:= printf "tags/%s/" . }}
+    <li class="rounded"><button href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</button></li>
+    {{ end }}
+  </ul>
 </div>


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Fixes #868 (Bug: extra anchor in post card tags)

### Description
I had to replace the tag anchor to a button. I kept the original design in both light and dark theme.

### Test Evidence
![image](https://github.com/hugo-toha/toha/assets/70479573/824a50ec-c9f8-421b-976a-5f849205d2bd)
![image](https://github.com/hugo-toha/toha/assets/70479573/3df1924d-3111-45ef-8d32-71f8d532c0cf)
![image](https://github.com/hugo-toha/toha/assets/70479573/46fa9042-57ff-4abf-ba7a-75a5ba43ad21)
![image](https://github.com/hugo-toha/toha/assets/70479573/e97c935f-38bb-4a85-a36c-00c0a110dcef)

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->