### PR TITLE
Fix hovering tags in posts

### DIFF
--- a/assets/styles/components/buttons.scss
+++ b/assets/styles/components/buttons.scss
@@ -56,14 +56,12 @@
     font-size: 0.5em;
     list-style-type: none;
     display: inline-block;
-    background: get-light-color('accent-color');
     margin-left: 0.2em;
     margin-right: 0.2em;
     margin-top: 0.6em;
     margin-bottom: 0.6em;
   }
   a {
-    color: get-light-color('text-over-accent-color');
     text-decoration: none !important;
   }
 }
@@ -141,17 +139,6 @@ html[data-theme='dark'] {
 
   .nav-button {
     color: get-dark-color('muted-text-color');
-  }
-
-  .tags {
-    li {
-      background: get-dark-color('accent-color');
-      a {
-        background-color: get-dark-color('bg-card');
-        border: 1px solid get-dark-color('muted-text-color');
-        color: get-dark-color('text-over-accent-color');
-      }
-    }
   }
 
   .icon-button {

--- a/layouts/partials/misc/tags.html
+++ b/layouts/partials/misc/tags.html
@@ -1,8 +1,8 @@
 <div class="tags">
-    <ul style="padding-left: 0;">
-      {{ range . }}
-      {{ $url:= printf "tags/%s/" . }}
-      <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn, btn-sm">{{ . }}</a></li>
-      {{ end }}
-    </ul>
+  <ul style="padding-left: 0;">
+    {{ range . }}
+    {{ $url:= printf "tags/%s/" . }}
+    <li class="rounded"><a href="{{ $url | urlize | relLangURL }}" class="btn btn-sm btn-info">{{ . }}</a></li>
+    {{ end }}
+  </ul>
 </div>


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Fixes #893 (Hovering a post card tag does not change appearance)

### Description
Added the `btn-info` class to tags (the one that publication tags have), and remove the unused tag styles (now inherited from `btn-info`)

### Test Evidence
I couldn't take screenshots with the cursor on the button, so you can visit my site https://bernatbc.me/ to check the changes. You can also check the netlify build preview.
<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->