### PR TITLE
Add tags in post cards from search results

### DIFF
--- a/assets/scripts/pages/search.js
+++ b/assets/scripts/pages/search.js
@@ -1,5 +1,6 @@
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
+import * as params from '@params'
 
 window.addEventListener('DOMContentLoaded', () => {
   const summaryInclude = 60
@@ -79,6 +80,15 @@ window.addEventListener('DOMContentLoaded', () => {
       // pull template from hugo template definition
       const templateDefinition = document.getElementById('search-result-template').innerHTML
       // replace values
+      function tagsHTML() {
+        if (!params.tags) return '';
+        const tags = value.item.tags;
+        let string = '<ul style="padding-left: 0;">';
+        tags.forEach((t) => {string += '<li class="rounded"><a href="/tags/' + t.toLowerCase() + '/" class="btn btn-sm btn-info">' + t + "</a></li>"});
+        string += "</ul>";
+        return string;
+      }
+
       const output = render(templateDefinition, {
         key,
         title: value.item.title,
@@ -86,7 +96,7 @@ window.addEventListener('DOMContentLoaded', () => {
         date: value.item.date,
         summary: value.item.summary,
         link: value.item.permalink,
-        tags: value.item.tags,
+        tags: tagsHTML(),
         categories: value.item.categories,
         snippet
       })

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -35,21 +35,26 @@
 
         <script id="search-result-template" type="text/x-js-template">
           <div class="post-card">
-            <a href="${link}" class="post-card-link">
-              <div class="card" style="min-height: 352px;"><a href="${link}" class="post-card-link">
+              <div class="card">
                 <div class="card-head">
+                  <a href="${link}" class="post-card-link">
                   <img class="card-img-top" src="${hero}" alt="Card Heading Image">
+                  </a>
                 </div>
                 <div class="card-body">
-                  <h5 class="card-title">${title}</h5>
-                  <p class="card-text post-summary">${summary}</p>
+                  <a href="${link}" class="post-card-link">
+                    <h5 class="card-title">${title}</h5>
+                    <p class="card-text post-summary">${summary}</p>
+                  </a>
+                  <div class="tags">
+                    ${tags}
+                  </div>
                 </div>
                 <div class="card-footer">
                   <span class="float-left">${date}</span>
                   <a href="${link}" class="float-right btn btn-outline-info btn-sm">Read</a>
                 </div>
               </div>
-	          </a>
           </div>
         </script>
 


### PR DESCRIPTION
### Issue
When tags are enabled in post cards, they don't appear in the post search results.

### Description
As you can see from the screenshot, if posts have different tags, the height is not adjusted at all. I've been looking how to get it fixed for a while, but I couldn't find the solution. If someone finds it, please tell me.

The other issue I have, is that at the moment I can only show tags when `enable: true`. The tags should be toggled when `on_card: true`.

### Test Evidence

#### Tags enabled:
![image](https://github.com/hugo-toha/toha/assets/70479573/ef957129-b4f9-4db9-ac4b-86b76e4b213b)

#### Tags disabled:
![image](https://github.com/hugo-toha/toha/assets/70479573/1097a315-1037-4177-9805-72e6cb707745)

