### PR TITLE
Fixes post cards in search results

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -34,7 +34,7 @@
 <section class="content-section" id="content-section">
   <div class="content container-fluid" id="content">
     <div class="container-fluid post-card-holder" id="post-card-holder">
-      <div id="search-results" style="display: flex;">
+      <div id="search-results" style="display: flex; flex-wrap: wrap;">
 
         <script id="search-result-template" type="text/x-js-template">
           <div class="post-card">


### PR DESCRIPTION
Hi @hossainemruz , thank you for fixing that issue related to the CSS of post cards of search results. After testing a little bit more, I encountered another issue.
### Issue
<!--- Insert a link to the associated github issue here. -->
Search results are displayed in a single line, reducing the width of each card. (See screenshot)

### Description
Fixes it by adding `flex-wrap: wrap` into `search-results` div.
<!-- Insert details about what the changes being proposed are. -->

### Test Evidence

#### Before
![image](https://github.com/hugo-toha/toha/assets/70479573/f79ca33a-cd55-4ecc-b50f-55ab1e8a0be9)

#### After
![image](https://github.com/hugo-toha/toha/assets/70479573/8ce2bc0f-689d-4417-9bcc-060ef0d8a273)
