### PR TITLE
Add dark logos

### DIFF
--- a/assets/scripts/features/darkmode/index.js
+++ b/assets/scripts/features/darkmode/index.js
@@ -39,6 +39,8 @@ window.addEventListener('load', async () => {
 
     // save preference to local storage
     saveScheme(newScheme)
+
+    setImages(newScheme)
   }
 
   setScheme(loadScheme())
@@ -50,3 +52,19 @@ window.addEventListener('load', async () => {
     })
   })
 })
+
+function setImages(newScheme) {
+  const els = Array.from(document.getElementsByClassName('logo-holder'));
+  for (const el of els) {
+    const light = el.querySelector('.light-logo');
+    const dark = el.querySelector('.dark-logo');
+    if (newScheme === "dark" && dark !== null) {
+      if (light !== null) light.style.display = 'none'
+      dark.style.display = 'inline'
+    }
+    else {
+      if (light !== null) light.style.display = 'inline'
+      if (dark !== null) dark.style.display = 'none'
+    }
+  }
+}

--- a/layouts/partials/sections/education-alt.html
+++ b/layouts/partials/sections/education-alt.html
@@ -33,9 +33,13 @@
                         <div class="degree-info card">
 
                             {{ $logoImage:= resources.Get .institution.logo}}
+                            {{ $darkLogoImage:= resources.Get .institution.darkLogo}}
                             {{ if $logoImage }}
-                            <div class="logo-holder">
-                                <img class="company-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+                            <div class="logo-holder"> 
+                                <img class="company-logo light-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+                                {{ if $darkLogoImage }}
+                                <img class="company-logo dark-logo" src="{{ $darkLogoImage.RelPermalink }}" alt="{{ .name }}" />
+                                {{ end }}
                             </div>
                             {{ end }}
 

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -33,9 +33,13 @@
                         <div class="degree-info card">
 
                             {{ $logoImage:= resources.Get .institution.logo}}
+                            {{ $darkLogoImage:= resources.Get .institution.darkLogo}}
                             {{ if $logoImage }}
-                            <div class="logo-holder">
-                                <img class="company-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+                            <div class="logo-holder"> 
+                                <img class="company-logo light-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+                                {{ if $darkLogoImage }}
+                                <img class="company-logo dark-logo" src="{{ $darkLogoImage.RelPermalink }}" alt="{{ .name }}" />
+                                {{ end }}
                             </div>
                             {{ end }}
 

--- a/layouts/partials/sections/experiences/positions.html
+++ b/layouts/partials/sections/experiences/positions.html
@@ -1,11 +1,15 @@
 <div class="col-10 col-lg-8">
     <div class="experience-entry-heading">
         {{ $logoImage:= resources.Get .company.logo}}
-            {{ if $logoImage }}
-            <div class="logo-holder">
-                <img class="company-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
-            </div>
+        {{ $darkLogoImage:= resources.Get .company.darkLogo}}
+        {{ if $logoImage }}
+        <div class="logo-holder"> 
+            <img class="company-logo light-logo" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" />
+            {{ if $darkLogoImage }}
+            <img class="company-logo dark-logo" src="{{ $darkLogoImage.RelPermalink }}" alt="{{ .name }}" />
             {{ end }}
+        </div>
+        {{ end }}
         <!-- Total experience duration on a company is time between the starting date of the oldest position and ending date of most recent position -->
         {{ $oldestPosition := index (last 1 .positions) 0}}
         {{ $mostRecentPosition := index (first 1 .positions) 0}}


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Closes #902 

### Description
The config for using this feature looks like this:

```yaml
- name: Studies
  icon: fa-graduation-cap
  timeframe: August 2023 - December 2023
  institution:
    name: University
    url: "https://www.example.com"
    logo: /images/school.png
    darkLogo: /images/school-dark.png
```

Basically, we just added:
```yaml
    darkLogo: /images/school-dark.png
```


### Test Evidence
I've provided two images. `logo` has black letters, and `darkLogo` has white letters. You can see below what's the behavior depending on the images provided

![image](https://github.com/hugo-toha/toha/assets/70479573/8f4fb8a6-023e-401d-bda9-917cdffa9ede)
![image](https://github.com/hugo-toha/toha/assets/70479573/3a78f7ef-921e-4b82-808d-afddf2eabcd8)

I'll add it to the guides after you approve it.
