### PR TITLE
Fix deprecation warning emitted by hugo

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -157,8 +157,8 @@
       {{ end }}
 
       <!-- Keep backward compatibility with old config.yaml -->
-      {{ if site.DisqusShortname }}
-        {{ partial "comments/disqus.html" (dict (slice "disqus" "shortName")  site.DisqusShortname) }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
+        {{ partial "comments/disqus.html" (dict (slice "disqus" "shortName")  .Site.Config.Services.Disqus.Shortname) }}
       {{ end }}
 
       </div>

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -56,6 +56,6 @@
 {{ end }}
 
 <!-- Keep backwards compatibility and consistency with HUGO defaults -->
-{{ if site.GoogleAnalytics }}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
 {{ end }}


### PR DESCRIPTION
When previewing the example site with latest hugo version v0.123.8, the following warnings are written to output:

```
INFO  deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.GoogleAnalytics.ID instead.
INFO  deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in a future release. Use .Site.Config.Services.Disqus.Shortname instead.
```

This PR fixes these issues.

Closes #856 
