### PR TITLE
Fix dark mode image setting when system dark is used

### DIFF
--- a/assets/scripts/features/darkmode/index.js
+++ b/assets/scripts/features/darkmode/index.js
@@ -40,7 +40,7 @@ window.addEventListener('load', async () => {
     // save preference to local storage
     saveScheme(newScheme)
 
-    setImages(newScheme)
+    setImages(theme)
   }
 
   setScheme(loadScheme())


### PR DESCRIPTION
### Issue
Images do not switch to dark view when system dark is used in theme mode.

### Description

Images do not switch to dark view when system dark is used in theme mode.

### Test Evidence

1. Change system theme to dark
2. Be sure that Dark mode is enabled in config.yaml
3. Add darkLogo to company item in experiences.yaml
4. Run website
5. Switch to system theme mode - it should be dark
6. All images are not switched to their dark representation