### PR TITLE
Fix font color of education pages in dark mode

### DIFF
--- a/assets/styles/components/texts.scss
+++ b/assets/styles/components/texts.scss
@@ -72,7 +72,8 @@ html[data-theme='dark'] {
   h2,
   h3,
   h4,
-  h5 {
+  h5,
+  h6 {
     color: get-dark-color('heading-color');
   }
 

--- a/assets/styles/sections/education.scss
+++ b/assets/styles/sections/education.scss
@@ -229,6 +229,11 @@ html[data-theme='dark'] {
               border-left: 2px solid get-dark-color('accent-color');
             }
           }
+          .custom-section {
+            .custom-content {
+              color: get-dark-color('text-color');
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
### Issue
Fixes #942  to make degree and name of customSections visible regardless of light or dark mode.

### Description

Some text is not visible in dark mode. For example, degree, GPA and name of custom sections.
Solution:
1. Added `h6` color in dark mode.
2. Added `custom-content` class color to the education page in dark mode.

### Test Evidence
#### Before
<img width="761" alt="image" src="https://github.com/hugo-toha/toha/assets/23612929/266c4b53-ab37-4dc7-b9f2-886c59b4b9e9">

#### After
Dark Mode:
<img width="764" alt="image" src="https://github.com/hugo-toha/toha/assets/23612929/735fcf1d-1d26-494a-9590-f73165bcd13a">
Light Mode:
<img width="758" alt="image" src="https://github.com/hugo-toha/toha/assets/23612929/f1752b1e-e3ec-4928-a7ee-ac4ee4beeb25">
