### PR TITLE
Update node version in 'autoprefixer.yml' workflow

### DIFF
--- a/.github/workflows/autoprefixer.yml
+++ b/.github/workflows/autoprefixer.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "15.x"
+          node-version: "20.x"
 
       - name: Run autoprefixer
         run: |


### PR DESCRIPTION
The [autoprefixer](https://github.com/hugo-toha/toha/actions/runs/10639791460/job/29498427880) workflow currently fails with HEAD of repo.