### PR TITLE
Fix list page card was breaking

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/hugo-toha/hugo-toha.github.io v0.0.0-20240730212302-83b19f7bd3b7 h1:RRonNzaf6/Ou9PqfXeKiRywkd+9KY7SVgfGBQXqXshM=
+github.com/hugo-toha/hugo-toha.github.io v0.0.0-20240730212302-83b19f7bd3b7/go.mod h1:yWw1t3trnfzv4t1lA9zh5pSsI0+kqqyg58ir8/kt6zk=

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -8,7 +8,7 @@
     <div class="card-body">
       <a href="{{ .RelPermalink | relLangURL }}" class="post-card-link">
         <h5 class="card-title">{{ .Title }}</h5>
-        <p class="card-text post-summary">{{ .Summary }}</p>
+        <p class="card-text post-summary">{{ .Summary | plainify }}</p>
       </a>
       {{ if and site.Params.features.tags.enable site.Params.features.tags.on_card }}
         {{ partial "misc/tags.html" .Params.tags }}


### PR DESCRIPTION
### Issue
Fixes https://github.com/hugo-toha/toha/issues/968

### Description

On Hugo `v0.134.0`, summary format has changed a little bit. We need to pipe to `plainify` to get the old behaviro.

Ref: https://github.com/gohugoio/hugo/releases/tag/v0.134.0

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->