### PR TITLE
Add support for canonical links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,9 +8,7 @@
     {{ template "_internal/twitter_cards.html" . }}
     <!------ ADD PAGE SPECIFIC HEADERS ------->
     {{ block "header" . }} {{ end }}
-    {{ with .Params.relcanonical }}
-      {{ partial "misc/canonical.html" . }}
-    {{ end }}
+    
     <!--================= add analytics if enabled =========================-->
     {{- partial "analytics.html" . -}}
     <script>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,9 @@
     {{ template "_internal/twitter_cards.html" . }}
     <!------ ADD PAGE SPECIFIC HEADERS ------->
     {{ block "header" . }} {{ end }}
-
+    {{ with .Params.relcanonical }}
+      {{ partial "misc/canonical.html" . }}
+    {{ end }}
     <!--================= add analytics if enabled =========================-->
     {{- partial "analytics.html" . -}}
     <script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,8 @@
 {{ define "header" }}
 <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Title }}{{ end }}" />
+{{ with .Params.relcanonical }}
+<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />
+{{ end }}
 {{ end }}
 
 {{ define "navbar" }}
@@ -45,7 +48,7 @@
         {{ else }}
         <div style="margin-bottom: 80px;"></div>
         {{ end }}
-        
+
         <div class="title">
           <h1>{{ .Page.Title }}</h1>
         </div>

--- a/layouts/partials/misc/canoncial.html
+++ b/layouts/partials/misc/canoncial.html
@@ -1,1 +1,0 @@
-<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />

--- a/layouts/partials/misc/canoncial.html
+++ b/layouts/partials/misc/canoncial.html
@@ -1,0 +1,1 @@
+<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />


### PR DESCRIPTION
### Issue
Fixes https://github.com/hugo-toha/toha/issues/1000

### Description

Add support for canonical links in frontmatter. If you post to an external site, and *also* want to post to your own site, you **must** use a `<link rel="canonical" ` in the header or search engines will refuse to index it (on either site!)

### Test Evidence
![canonical1](https://github.com/user-attachments/assets/46d2b8aa-bb79-4d0a-bb3c-2cd428af34c9)

![canonical2](https://github.com/user-attachments/assets/9fcf3280-7153-43b1-aa34-9fedbc4fd672)
