### PR TITLE
Add statcounter to statistics

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -93,7 +93,7 @@ params:
 
     # Enable dark theme
     darkMode:
-    
+
     # [Deprecated] Enable dark theme
     # This is a deprecated setting, but has not been removed to maintain backward compatibility
     # If `theme` is set, the `darkMode` setting will be discarded.
@@ -192,7 +192,11 @@ params:
         #   scheme: https
         #   instance: umami.example.com
         #   id: <your umami site id>
-
+        # # Statcounter
+        # statcounter:
+        #   project: 1234567890
+        #   invisible: 1
+        #   security: deadbeef
     # Enable Support
     support:
       enable: false
@@ -287,7 +291,7 @@ params:
         plyr:
           # options doc: https://github.com/sampotts/plyr#options
           # fullscreen: true
-    
+
     # Enables copy code button
     copyCodeButton:
       enable: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,9 @@
     {{ template "_internal/twitter_cards.html" . }}
     <!------ ADD PAGE SPECIFIC HEADERS ------->
     {{ block "header" . }} {{ end }}
-
+    {{ with .Params.relcanonical }}
+      {{ partial "misc/canonical.html" . }}
+    {{ end }}
     <!--================= add analytics if enabled =========================-->
     {{- partial "analytics.html" . -}}
     <script>

--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -57,6 +57,25 @@
             <script defer src='{{ or .scheme "https" }}://{{ or .instance "analytics.eu.umami.is" }}/script.js' data-website-id="{{ .id }}"></script>
             <!-- End Umami analytics -->
             {{end}}
+
+            {{ with .statcounter }}
+            <!-- Statcounter analytics -->
+            <script type="text/javascript" src="https://www.statcounter.com/counter/counter.js" async></script>
+            <script type="text/javascript">
+              var sc_project = {{ .project }};
+              var sc_invisible = {{ .invisible }};
+              var sc_security = "{{ .security }}";
+              var scJsHost = (("https:" == document.location.protocol) ?
+                "https://www.statcounter.com/js/" : "https://www.statcounter.com/js/");
+            </script>
+            <noscript>
+              <div class="statcounter"><a title="web counter" href="https://statcounter.com/" target="_blank"><img
+                    class="statcounter" src="https://c.statcounter.com/{{ .project }}/0/{{ .security }}/{{ .invisible }}/"
+                    alt="web counter" referrerPolicy="no-referrer-when-downgrade"></a></div>
+                <!-- End of Statcounter Code -->
+            </noscript>
+            <!-- End Statcounter analytics -->
+            {{ end }}
         {{ end }}
     {{ end }}
 {{ end }}

--- a/layouts/partials/misc/canoncial.html
+++ b/layouts/partials/misc/canoncial.html
@@ -1,1 +1,0 @@
-<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />

--- a/layouts/partials/misc/canoncial.html
+++ b/layouts/partials/misc/canoncial.html
@@ -1,0 +1,1 @@
+<link rel="canonical" href="{{ . | relLangURL }}" itemprop="url" />


### PR DESCRIPTION
### Issue
No issue created
### Description
[statcounter](https://statcounter.com) is a popular web stats site. Integrating it into toha was (previously) a pain, so this PR makes it super simple.

It follows the same configuration rules as the other web analytics options. 

### Test Evidence

![statcounter-2](https://github.com/user-attachments/assets/1f65aead-c537-4e2d-ba93-9c6d1020a821)
![statcounter-1](https://github.com/user-attachments/assets/75e7c094-7334-4aed-b8ee-f49bf2257bb4)

The configuration parameters are picked up and put into the stat counter code in the header, as expected.