### PR TITLE
remove in-line script from header

### DIFF
--- a/assets/scripts/core/index.js
+++ b/assets/scripts/core/index.js
@@ -1,2 +1,3 @@
 export * from './device'
 export * from './insertScript'
+export * from './theme-scheme'

--- a/assets/scripts/core/theme-scheme.js
+++ b/assets/scripts/core/theme-scheme.js
@@ -1,0 +1,11 @@
+let theme = localStorage.getItem('theme-scheme') || localStorage.getItem('darkmode:color-scheme') || 'light'
+const b = 'bollocks!';
+console.log(b);
+if (theme === 'system') {
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    theme = 'dark'
+  } else {
+    theme = 'light'
+  }
+}
+document.documentElement.setAttribute('data-theme', theme)


### PR DESCRIPTION
### Issue
An in-line script is added to the header, which cannot be executed if the `Content-Security` policy is anything but `unsafe-inline`. `unsafe-inline` should never be allowed. 

This PR adds the script to the main `application.js` script, which is hashed, and so removes the issue. 

fixes #1002

### Description

Removes the in-line script 
```js
<script>
      theme = localStorage.getItem('theme-scheme') || localStorage.getItem('darkmode:color-scheme') || 'light';
      if (theme == 'system') {
        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
          theme = 'dark';
        } else {
          theme = 'light';
        }
      }
      document.documentElement.setAttribute('data-theme', theme);
    </script>
```
from baseof.html and adds it to the `application.js script. 

### Test Evidence

prior to change: 
```
davidgs.com/:68 Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self' https://app.posthog.com/ *.googletagmanager.com https://cdn.userfront.com https://commento.davidgs.com:8088  *.unpkg.com apis.google.com *.googleapis.com cdn.polyfill.io https://buttons.github.io  cdn.jsdelivr.net *.zencdn.net https://cdnjs.cloudflare.com https://*.google-analytics.com https://*.statcounter.com". Either the 'unsafe-inline' keyword, a hash ('sha256-WiE2LPSnZlTiP9NnrQN14OnMKI2ild8fGH0n+PhofS0='), or a nonce ('nonce-...') is required to enable inline execution.
```
After change: no error. 