### PR TITLE
Fix input focus and placeholder color for footer section

### DIFF
--- a/assets/styles/sections/footer.scss
+++ b/assets/styles/sections/footer.scss
@@ -97,6 +97,10 @@ html[data-theme='dark'] {
       background-color: get-dark-color('bg-primary');
       &:focus {
         background-color: get-dark-color('bg-secondary');
+        color: get-dark-color('text-color');
+      }
+      &::placeholder {
+        color: get-dark-color('muted-text-color');
       }
     }
 


### PR DESCRIPTION
### Issue
Solved https://github.com/hugo-toha/hugo-toha.github.io/issues/348

### Description

Input text cannot be seen in dark mode. Fix it by modifying the css.

### Test Evidence
#### Before
![image](https://github.com/user-attachments/assets/019a435e-28ad-4e66-9351-fb601ff5c37b)

#### After
Placeholder
![image](https://github.com/user-attachments/assets/3feab6d9-a5a1-4b62-ba49-a0a83a02a62d)
Focus
![image](https://github.com/user-attachments/assets/9a312a21-587d-4a56-a2a9-d3e8b03371e0)
