### PR TITLE
Make Phone Number Clickable in Footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -106,7 +106,9 @@
                   <span><i class="fas fa-envelope"></i></span> <span>{{ $value }}</span>
                 </a></li>
               {{ else if (eq $key "phone") }}
-                <li><span><i class="fas fa-phone-alt"></i></span> <span>{{ $value }}</span></li>
+                <li><a href={{ printf "tel:%s" $value | safeURL }} target="_blank" rel="noopener">
+                  <span><i class="fas fa-phone-alt"></i></span> <span>{{ $value }}</span>
+                </a></li>
               {{ else if (eq $key "linkedin") }}
                 <li><a href={{ printf "https://www.linkedin.com/in/%s" $value }} target="_blank" rel="noopener">
                   <span><i class="fab fa-linkedin"></i></span> <span>{{ $author.name }}</span>


### PR DESCRIPTION
### Issue

No related issue.

### Description

This pull request updates the `footer.html` partial file to improve user experience by wrapping the existing phone number `<span>` element in a clickable `<a>` tag with the `tel:` protocol. This change allows users to easily initiate a call or access contact software on their devices by clicking or tapping on the phone number.

**Changes Made:**

- Wrapped the phone number `<span>` in an `<a>` tag with the `tel:` attribute in `layouts/partials/footer.html`.
- Ensured that the phone number is now clickable on both mobile and desktop devices.

**Benefits:**

- Enhances accessibility and usability for users wishing to contact us directly.
- Simplifies the process of making phone calls from the website.


### Test Evidence

Trust me bro.

![Screenshot (1)-cropped](https://github.com/user-attachments/assets/2cdd6d98-98fa-478e-8d59-d016f0d79841)