### PR TITLE
Fix #1037 Close Nav Menu after selection

### DIFF
--- a/assets/scripts/sections/navbar.js
+++ b/assets/scripts/sections/navbar.js
@@ -54,8 +54,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const navMain = document.getElementsByClassName('navbar-collapse')
   Array.from(navMain).forEach(function (el) {
     el.addEventListener('click', function (e) {
-      if (e.target.tagName === 'A') {
+      if (e.target.tagName === 'A' && !e.target.classList.contains("dropdown-toggle")) {
         el.classList.add('collapse')
+        el.classList.remove('show')
       }
     })
   })


### PR DESCRIPTION
### Issue
After selecting an item in the mobile version of the navbar, the navbar should close itself.

### Description

Close the NavBar after clicking the menu. Ignore the drop-down list's parent menu's actions.

### Test Evidence

1. Resize the browser until the navmenu with 3 lines appears or test on a mobile device.
2. Select an item to navigate towards.
3. The menu should close.