### PR TITLE
#1077 issue

### DIFF
--- a/assets/styles/sections/publications.scss
+++ b/assets/styles/sections/publications.scss
@@ -29,8 +29,8 @@
         text-decoration: underline; /* Underline only when href is present */
       }
       
-      a:not([href]) {
-        text-decoration: none; /* No underline when href is absent */
+      .author-name {
+        color: get-light-color('text-color'); /* Use text color for authors without URLs */
       }
     }
 
@@ -129,6 +129,10 @@ html[data-theme='dark'] {
       .card-header {
         .sub-title {
           color: get-dark-color('muted-text-color');
+        }
+        
+        .author-name {
+          color: get-dark-color('text-color'); /* Use text color for authors without URLs in dark mode */
         }
       }
 

--- a/assets/styles/sections/publications.scss
+++ b/assets/styles/sections/publications.scss
@@ -26,11 +26,11 @@
       }
 
       a[href] {
-        text-decoration: underline; /* Underline only when href is present */
+        text-decoration: underline;
       }
       
-      .author-name {
-        color: get-light-color('text-color'); /* Use text color for authors without URLs */
+      a:not([href]) {
+        text-decoration: none; /* No underline when href is absent */
       }
     }
 
@@ -129,10 +129,6 @@ html[data-theme='dark'] {
       .card-header {
         .sub-title {
           color: get-dark-color('muted-text-color');
-        }
-        
-        .author-name {
-          color: get-dark-color('text-color'); /* Use text color for authors without URLs in dark mode */
         }
       }
 

--- a/layouts/partials/cards/publication.html
+++ b/layouts/partials/cards/publication.html
@@ -25,7 +25,7 @@
         {{if .url}}
           <span class="me-2"><a class="" href="{{.url}}">{{ .name }}</a></span>
         {{ else }}
-        <span class="me-2"><a class="">{{ .name }}</a></span>
+        <span class="me-2 author-name">{{ .name }}</span>
         {{ end }}
         {{ end }}
       </div>


### PR DESCRIPTION
### Description for **issue** #1077

Fix author link visibility in dark mode for publication cards. Replace empty anchor tags with proper span elements for authors without URLs and addition of appropriate styling to ensure text is readable in both light and dark themes. And removal unnecessary comments and clean up CSS structure for better maintainability.

### Test Evidence

Test by viewing publications with authors that don't have URLs in both light and dark modes author names should be clearly visible and properly styled without underline decoration.