### PR TITLE
fix: navbar overlay for tags/categories (hugo-toha#1041)

### DIFF
--- a/assets/styles/navigators/sidebar.scss
+++ b/assets/styles/navigators/sidebar.scss
@@ -1,11 +1,11 @@
 .sidebar-section {
+  margin-top: 2.5rem;
   order: 1;
   flex: 20%;
   max-width: 20%;
   @include transition();
 
   .sidebar-holder {
-    top: 2.5rem;
     position: sticky;
     background-color: get-light-color('bg-primary');
     height: 100vh;


### PR DESCRIPTION
### Issue
The navbar overlays the sidebar on the tags/categories page.

### Description

Fixing navbar overlay to the sidebar of tags/categories

### Test Evidence

<img width="512" height="460" alt="Screenshot 2025-10-06 232113" src="https://github.com/user-attachments/assets/676e72c4-6a44-431b-8992-1779b03366c1" />

<img width="608" height="409" alt="image" src="https://github.com/user-attachments/assets/8f6efe20-fbbd-4727-a9eb-995b2c1da267" />
